### PR TITLE
terranixConfiguration: format generated json

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,10 +89,7 @@
           };
           terranixCore = import ./core/default.nix terranix_args;
         in
-        pkgs.writeTextFile {
-          name = "config.tf.json";
-          text = builtins.toJSON terranixCore.config;
-        };
+        (pkgs.formats.json { }).generate "config.tf.json" terranixCore.config;
 
       # create a options.json.
       # you have to either have to name a system or set pkgs.


### PR DESCRIPTION
Use `pkgs.formats.json` to format the JSON output. This allows for easier human reading of the generated config.