### PR TITLE
fix a few typos in docs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,31 +3,29 @@ all: man-terranix_description.refsection.xml man-terranix_functions.refsection.x
 
 
 %.refsection.xml: %.refsection.md
-	pandoc $^ -w docbook+smart \
+	pandoc $^ -w docbook \
 		-f markdown+smart \
 	  | sed -e 's|<ulink url=|<link xlink:href=|' \
 	      -e 's|</ulink>|</link>|' \
 	      -e 's|<sect. id=|<section xml:id=|' \
 	      -e 's|</sect[0-9]>|</section>|' \
 	      -e '1s| id=| xml:id=|' \
-	      -e '1s|\(<[^ ]* \)|\1xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" |' \
 	      -e 's|<section|<refsection|' \
 	      -e 's|</section>|</refsection>|' \
 	| cat  > $@
 
 %.section.xml: %.section.md
-	pandoc $^ -w docbook+smart \
+	pandoc $^ -w docbook \
 		-f markdown+smart \
 	  | sed -e 's|<ulink url=|<link xlink:href=|' \
 	      -e 's|</ulink>|</link>|' \
 	      -e 's|<sect. id=|<section xml:id=|' \
 	      -e 's|</sect[0-9]>|</section>|' \
 	      -e '1s| id=| xml:id=|' \
-	      -e '1s|\(<[^ ]* \)|\1xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" |' \
 	| cat  > $@
 
 %.chapter.xml: %.chapter.md
-	pandoc $^ -w docbook+smart \
+	pandoc $^ -w docbook \
 		--top-level-division=chapter \
 		-f markdown+smart \
 	  | sed -e 's|<ulink url=|<link xlink:href=|' \

--- a/doc/man-terranix-doc_description.refsection.xml
+++ b/doc/man-terranix-doc_description.refsection.xml
@@ -1,4 +1,4 @@
-<refsection xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refsection xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="description">
   <title>Description</title>
   <para>
     Render all available options usable by a given

--- a/doc/man-terranix-doc_options.refsection.xml
+++ b/doc/man-terranix-doc_options.refsection.xml
@@ -1,4 +1,4 @@
-<refsection xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refsection xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="options">
   <title>Options</title>
   <variablelist spacing="compact">
     <varlistentry>

--- a/doc/man-terranix_functions.refsection.md
+++ b/doc/man-terranix_functions.refsection.md
@@ -1,8 +1,7 @@
-
 # FUNCTIONS
 
 Nix comes with a ton of functions that
-make your live easier.
+make your life easier.
 
 A good overview can be found 
 [here]( https://storage.googleapis.com/files.tazj.in/nixdoc/manual.html#sec-functions-library).
@@ -10,10 +9,10 @@ A good overview can be found
 ## optionalAttrs
 
 Useful to create a resource depending on a condition.
-The following example adds a bation host only if
+The following example adds a bastion host only if
 the variable `bastionHostEnable` is set to true.
 
-This is just an example for illustration and such things
+This is just an example for illustration, but such things
 are better solved using
 [modules](https://nixos.wiki/wiki/NixOS_Modules).
 
@@ -38,12 +37,12 @@ in
 : map a list to another list.
 
 `zipAttrs`
-: Merge sets of attributes and combine each attribute value in to a list.
+: merge sets of attributes and combine each attribute value into a list.
 
 Useful to create resources out of a small amount
-of information with containing a lot of similar data.
+of information by containing a lot of similar data.
 
-The following Example shows how to create 3 s3buckets with the same configuration.
+The following example shows how to create 3 s3buckets with the same configuration.
 
 ```nix
 { lib, ... }:

--- a/doc/man-terranix_functions.refsection.xml
+++ b/doc/man-terranix_functions.refsection.xml
@@ -1,7 +1,7 @@
 <refsection xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="functions">
   <title>FUNCTIONS</title>
   <para>
-    Nix comes with a ton of functions that make your live easier.
+    Nix comes with a ton of functions that make your life easier.
   </para>
   <para>
     A good overview can be found
@@ -11,11 +11,11 @@
     <title>optionalAttrs</title>
     <para>
       Useful to create a resource depending on a condition. The
-      following example adds a bation host only if the variable
+      following example adds a bastion host only if the variable
       <literal>bastionHostEnable</literal> is set to true.
     </para>
     <para>
-      This is just an example for illustration and such things are
+      This is just an example for illustration, but such things are
       better solved using
       <link xlink:href="https://nixos.wiki/wiki/NixOS_Modules">modules</link>.
     </para>
@@ -54,18 +54,18 @@ in
         </term>
         <listitem>
           <para>
-            Merge sets of attributes and combine each attribute value in
-            to a list.
+            merge sets of attributes and combine each attribute value
+            into a list.
           </para>
         </listitem>
       </varlistentry>
     </variablelist>
     <para>
-      Useful to create resources out of a small amount of information
-      with containing a lot of similar data.
+      Useful to create resources out of a small amount of information by
+      containing a lot of similar data.
     </para>
     <para>
-      The following Example shows how to create 3 s3buckets with the
+      The following example shows how to create 3 s3buckets with the
       same configuration.
     </para>
     <programlisting language="bash">

--- a/doc/man-terranix_hcl.refsection.md
+++ b/doc/man-terranix_hcl.refsection.md
@@ -3,8 +3,8 @@
 The
 [nix syntax](https://nixos.org/nix/manual/)
 is similiar to the
-[HCL syntax](https://github.com/hashicorp/hcl)
-but, much more powerfull.
+[HCL syntax](https://github.com/hashicorp/hcl),
+but much more powerful.
 
 In **HCL** you would do something like this:
 
@@ -32,9 +32,9 @@ resource."aws_instance"."web" = {
 
 The same holds for `variable`, `output`, `data` and `provider`.
 
-## multi line sings
+## multi line strings
 
-In terraform you can create multi line strings using the `herdoc` style
+In terraform you can create multi line strings using the `heredoc` style
 
 ```hcl
 variable "multiline" {
@@ -60,13 +60,13 @@ variable.multiline.description = ''
 ## escaping expressions
 
 The form `${expression}` is used by terranix and terraform.
-So if you want to use a terraform expression in terranix,
+So, if you want to use a terraform expression in terranix,
 you have to escape it.
-There are the two context, multi and singe line strings.
+There are the two context, multi and single line strings.
 
 ### escaping expressions in single line strings
 
-In a single line strings, you escape the via `\${expression}`.
+In single line strings, you escape the via `\${expression}`.
 For example :
 
 ```nix
@@ -76,7 +76,7 @@ provider.hcloud.token = "\${var.hcloud_token}";
 
 ### escaping expressions in multi line strings
 
-In multi line strings, you escape the via `''${expression}`.
+In multi line strings, you escape via `''${expression}`.
 For example :
 
 ```nix

--- a/doc/man-terranix_hcl.refsection.xml
+++ b/doc/man-terranix_hcl.refsection.xml
@@ -4,7 +4,7 @@
     The <link xlink:href="https://nixos.org/nix/manual/">nix
     syntax</link> is similiar to the
     <link xlink:href="https://github.com/hashicorp/hcl">HCL
-    syntax</link> but, much more powerfull.
+    syntax</link>, but much more powerful.
   </para>
   <para>
     In <emphasis role="strong">HCL</emphasis> you would do something
@@ -37,11 +37,11 @@ resource.&quot;aws_instance&quot;.&quot;web&quot; = {
     <literal>output</literal>, <literal>data</literal> and
     <literal>provider</literal>.
   </para>
-  <refsection xml:id="multi-line-sings">
-    <title>multi line sings</title>
+  <refsection xml:id="multi-line-strings">
+    <title>multi line strings</title>
     <para>
       In terraform you can create multi line strings using the
-      <literal>herdoc</literal> style
+      <literal>heredoc</literal> style
     </para>
     <programlisting>
 variable &quot;multiline&quot; {
@@ -68,14 +68,14 @@ variable.multiline.description = ''
     <title>escaping expressions</title>
     <para>
       The form <literal>${expression}</literal> is used by terranix and
-      terraform. So if you want to use a terraform expression in
+      terraform. So, if you want to use a terraform expression in
       terranix, you have to escape it. There are the two context, multi
-      and singe line strings.
+      and single line strings.
     </para>
     <refsection xml:id="escaping-expressions-in-single-line-strings">
       <title>escaping expressions in single line strings</title>
       <para>
-        In a single line strings, you escape the via
+        In single line strings, you escape the via
         <literal>\${expression}</literal>. For example :
       </para>
       <programlisting language="bash">
@@ -86,7 +86,7 @@ provider.hcloud.token = &quot;\${var.hcloud_token}&quot;;
     <refsection xml:id="escaping-expressions-in-multi-line-strings">
       <title>escaping expressions in multi line strings</title>
       <para>
-        In multi line strings, you escape the via
+        In multi line strings, you escape via
         <literal>''${expression}</literal>. For example :
       </para>
       <programlisting language="bash">

--- a/doc/man-terranix_modules.refsection.md
+++ b/doc/man-terranix_modules.refsection.md
@@ -1,14 +1,14 @@
 # MODULES
 
-The real power behind NixOS and terranix,
-is the module system which is fundamentaly different to the
+The real power behind NixOS and terranix
+is the module system, which is fundamentally different to the
 Terraform Module system.
-Detailed information can be optained at the
+Detailed information can be obtained at the
 [NixOS Wiki](https://nixos.wiki/wiki/NixOS_Modules).
 
 ## Module Structure
 
-A module looks always like this:
+A module always looks like this:
 
 ```nix
 { config, lib, pkgs, ... }:
@@ -29,7 +29,7 @@ A module looks always like this:
 
 ## Example Module
 
-Here is an example Module to enable bastion host setups.
+Here is an example module to enable bastion host setups.
 
 ```nix
 { config, lib, pkgs, ... }:

--- a/doc/man-terranix_modules.refsection.xml
+++ b/doc/man-terranix_modules.refsection.xml
@@ -1,16 +1,16 @@
 <refsection xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="modules">
   <title>MODULES</title>
   <para>
-    The real power behind NixOS and terranix, is the module system which
-    is fundamentaly different to the Terraform Module system. Detailed
-    information can be optained at the
+    The real power behind NixOS and terranix is the module system, which
+    is fundamentally different to the Terraform Module system. Detailed
+    information can be obtained at the
     <link xlink:href="https://nixos.wiki/wiki/NixOS_Modules">NixOS
     Wiki</link>.
   </para>
   <refsection xml:id="module-structure">
     <title>Module Structure</title>
     <para>
-      A module looks always like this:
+      A module always looks like this:
     </para>
     <programlisting language="bash">
 { config, lib, pkgs, ... }:
@@ -32,7 +32,7 @@
   <refsection xml:id="example-module">
     <title>Example Module</title>
     <para>
-      Here is an example Module to enable bastion host setups.
+      Here is an example module to enable bastion host setups.
     </para>
     <programlisting language="bash">
 { config, lib, pkgs, ... }:


### PR DESCRIPTION
Fix some typos in the docs.

Reason for other changes:
  - I couldn't figure out how to run the build to get the current output.  In my pandoc (the latest fron nixpkgs unstable), the `docbook+smart` option fails with `The extension smart is not supported for docbook`.  This looks like it also broke nixpkgs [two years ago](https://github.com/NixOS/nixpkgs/commit/83015ff7954a1a111737359ac644443327ce6f6f) and the fix is to get rid of the `+smart`.
  - I also removed the `xmlns` `sed` command from the `Makefile` because, otherwise, it was being duplicated.  I assume the newer pandoc just adds `xmlns` correctly.