### PR TITLE
Make resource and data referenceable

### DIFF
--- a/core/default.nix
+++ b/core/default.nix
@@ -24,10 +24,11 @@ let
       null = null;
       set =
         let
+          pred = name: value: name != "_module" && name != "_ref" && name != "__functor";
           stripped_a = lib.flip lib.filterAttrs configuration
-            (name: value: name != "_module" && name != "_ref");
+            (name: value: pred name value);
           stripped_b = lib.flip lib.filterAttrs configuration
-            (name: value: name != "_module" && name != "_ref" && value != null);
+            (name: value: pred name value && value != null);
           recursiveSanitized =
             if strip_nulls then
               lib.mapAttrs (lib.const sanitize) stripped_b

--- a/core/terraform-options.nix
+++ b/core/terraform-options.nix
@@ -6,9 +6,9 @@
 with lib;
 
 let
-  mkMagicMergeOption = { description ? "", example ? { }, default ? { }, ... }:
+  mkMagicMergeOption = { description ? "", example ? { }, default ? { }, apply ? id, ... }:
     mkOption {
-      inherit example description default;
+      inherit example description default apply;
       type = with lib.types;
         let
           valueType = nullOr
@@ -26,11 +26,19 @@ let
         in
         valueType;
     };
+
+  mkReferenceableOption = { ... }@args:
+    mkMagicMergeOption (args // {
+      apply = mapAttrs (type: v1:
+        mapAttrs (label: v2:
+          v2 // { __functor = self: attr: "\${${type}.${label}.${attr}}"; })
+        v1);
+    });
 in
 {
 
   options = {
-    data = mkMagicMergeOption {
+    data = mkReferenceableOption {
       description = ''
         Data objects, are queries to use resources which
         are already exist, as if they are created by a the resource
@@ -87,7 +95,7 @@ in
         or https://www.terraform.io/docs/providers/index.html
       '';
     };
-    resource = mkMagicMergeOption {
+    resource = mkReferenceableOption {
       example = {
         resource.aws_instance.web = {
           ami = "ami-a1b2c3d4";


### PR DESCRIPTION
After this pr being merged, if user has a definition of `resource.aws_s3_bucket.my_s3_bucket` and he would like to reference attributes of such resource in other places, instead of writing `"\${aws_s3_bucket.my_s3_bucket.arn}"`, he could use `config.resource.aws_s3_bucket.my_s3_bucket "arn"`, which produces a same string.