### PR TITLE
fix: pkgs is not consumed in this scope

### DIFF
--- a/core/default.nix
+++ b/core/default.nix
@@ -6,7 +6,6 @@
 , strip_nulls ? true
 }:
 
-with pkgs;
 with pkgs.lib;
 with builtins;
 
@@ -15,7 +14,7 @@ let
   # sanitize the resulting configuration
   # removes unwanted parts of the evalModule output
   sanitize = configuration:
-    lib.getAttr (typeOf configuration) {
+    getAttr (typeOf configuration) {
       bool = configuration;
       int = configuration;
       string = configuration;
@@ -24,15 +23,15 @@ let
       null = null;
       set =
         let
-          stripped_a = lib.flip lib.filterAttrs configuration
+          stripped_a = flip filterAttrs configuration
             (name: value: name != "_module" && name != "_ref");
-          stripped_b = lib.flip lib.filterAttrs configuration
+          stripped_b = flip filterAttrs configuration
             (name: value: name != "_module" && name != "_ref" && value != null);
           recursiveSanitized =
             if strip_nulls then
-              lib.mapAttrs (lib.const sanitize) stripped_b
+              mapAttrs (const sanitize) stripped_b
             else
-              lib.mapAttrs (lib.const sanitize) stripped_a;
+              mapAttrs (const sanitize) stripped_a;
         in
         if (length (attrNames configuration) == 0) then
           { }
@@ -44,7 +43,6 @@ let
   # also include all the default modules
   # https://github.com/NixOS/nixpkgs/blob/master/lib/modules.nix#L95
   evaluateConfiguration = configuration:
-    with lib;
     evalModules {
       modules = [
         { imports = [ ./terraform-options.nix ../modules ]; }

--- a/modules/provider/cloudflare.nix
+++ b/modules/provider/cloudflare.nix
@@ -1,5 +1,5 @@
 # this file will be removed and provided by a module
-{ config, lib, pkgs, ... }:
+{ config, lib, ... }:
 
 with lib;
 

--- a/modules/provisioner.nix
+++ b/modules/provisioner.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, ... }:
 
 with lib;
 

--- a/modules/terraform/backends.nix
+++ b/modules/terraform/backends.nix
@@ -1,5 +1,5 @@
 # manage backend configurations and terraform_remote_state configurations
-{ config, lib, pkgs, ... }:
+{ config, lib, ... }:
 
 with lib;
 


### PR DESCRIPTION
to avoid false leads when assessing the target system context of pkgs, don't declare it in scope here

If tests are green, then this was probably a valid cleanup :smile: 

I tried `nix flake check`:

```console
terranix on  cleanup-be-explicit-about-consuming-or-not-pkgs
❯ nix flake check
warning: unknown flake output 'lib'
warning: flake output attribute 'defaultPackage' is deprecated; use 'packages.<system>.default' instead
warning: flake output attribute 'devShell' is deprecated; use 'devShells.<system>.default' instead
warning: flake output attribute 'defaultApp' is deprecated; use 'apps.<system>.default' instead
warning: flake output attribute 'defaultTemplate' is deprecated; use 'templates.default' instead

terranix on  cleanup-be-explicit-about-consuming-or-not-pkgs took 26s
❯ echo $?
```

```console
❯ nix run .#test
warning: Git tree '/home/blaggacao/src/github.com/terranix/terranix' is dirty
          \\\///
         / _  _ \
       (| (.)(.) |)
.----.OOOo--()--oOOO.----.
|                        |
| running terranix tests |
|                        |
'----.oooO---------------'
      (   )   Oooo.
       \ (    (   )
        \_)    ) /
              (_/
 ✓ backend : setting a backend
 ✓ backend : setting 2 terranixs will fail
 ✓ remote_state : 2 remote states with the same names are forbidden
 ✓ remote_state : 2 remote states with differente names are ok
 ✓ assert : don't trigger error on true mkAssert
 ✓ assert : trigger error on false mkAssert
 ✓ strip-nulls: print no nulls without --with-nulls
 ✓ strip-nulls: print nulls with --with-nulls
 ✓ magic-merge: works for attrs and lists
 ✓ magic-merge: fails for setting different types
 ✓ magic-merge: leave empty sets untouched
 ✓ empty resources: should be filtered out
 ✓ terranix-doc-json: works with simple module
 ✓ terranix-doc-json: works with empty module

14 tests, 0 failure
```