### PR TITLE
fix: error message on types

### DIFF
--- a/core/terraform-options.nix
+++ b/core/terraform-options.nix
@@ -20,7 +20,7 @@ let
               (attrsOf valueType)
               (listOf valueType)
             ]) // {
-            description = "";
+            description = "bool, int, float or str";
             emptyValue.value = { };
           };
         in


### PR DESCRIPTION
A definition for option 'module.acm.source' is not of type 'bool, int, float or str'

Before: A definition for option 'module.acm.source' is not of type ''.
