### PR TITLE
Pin tests to avoid failures due to different nixpkgs versions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,7 @@
       apps.test =
         let
           tests = import ./tests/test.nix {
+            inherit nixpkgs;
             inherit pkgs;
             inherit (pkgs) lib;
             terranix = self.packages.${system}.terranix;

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -1,17 +1,17 @@
-{ pkgs, lib, terranix, ... }:
+{ nixpkgs, pkgs, lib, terranix, ... }:
 
 
 with lib; [
 
   ''
     @test "backend : setting a backend" {
-    run ${terranix}/bin/terranix --quiet ${./terranix-tests/01.nix}
+    run ${terranix}/bin/terranix --quiet --pkgs ${nixpkgs} ${./terranix-tests/01.nix}
     assert_success
     assert_output ${escapeShellArg (fileContents ./terranix-tests/01.nix.output)}
     }
 
     @test "backend : setting 2 terranixs will fail" {
-    run ${terranix}/bin/terranix --quiet ${./terranix-tests/02.nix}
+    run ${terranix}/bin/terranix --quiet --pkgs ${nixpkgs} ${./terranix-tests/02.nix}
     assert_failure
     assert_output ${escapeShellArg (fileContents ./terranix-tests/02.nix.output)}
     }
@@ -19,13 +19,13 @@ with lib; [
 
   ''
     @test "remote_state : 2 remote states with the same names are forbidden" {
-    run ${terranix}/bin/terranix --quiet ${./terranix-tests/03.nix}
+    run ${terranix}/bin/terranix --quiet --pkgs ${nixpkgs} ${./terranix-tests/03.nix}
     assert_failure
     assert_output ${escapeShellArg (fileContents ./terranix-tests/03.nix.output)}
     }
 
     @test "remote_state : 2 remote states with differente names are ok" {
-    run ${terranix}/bin/terranix --quiet ${./terranix-tests/04.nix}
+    run ${terranix}/bin/terranix --quiet --pkgs ${nixpkgs} ${./terranix-tests/04.nix}
     assert_success
     assert_output ${escapeShellArg (fileContents ./terranix-tests/04.nix.output)}
     }
@@ -33,13 +33,13 @@ with lib; [
 
   ''
     @test "assert : don't trigger error on true mkAssert " {
-    run ${terranix}/bin/terranix --quiet ${./terranix-tests/05.nix}
+    run ${terranix}/bin/terranix --quiet --pkgs ${nixpkgs} ${./terranix-tests/05.nix}
     assert_success
     assert_output ${escapeShellArg (fileContents ./terranix-tests/05.nix.output)}
     }
 
     @test "assert : trigger error on false mkAssert " {
-    run ${terranix}/bin/terranix --quiet ${./terranix-tests/06.nix}
+    run ${terranix}/bin/terranix --quiet --pkgs ${nixpkgs} ${./terranix-tests/06.nix}
     assert_failure
     assert_output ${escapeShellArg (fileContents ./terranix-tests/06.nix.output)}
     }
@@ -47,13 +47,13 @@ with lib; [
 
   ''
     @test "strip-nulls: print no nulls without --with-nulls" {
-    run ${terranix}/bin/terranix --quiet ${./terranix-tests/07.nix}
+    run ${terranix}/bin/terranix --quiet --pkgs ${nixpkgs} ${./terranix-tests/07.nix}
     assert_success
     assert_output ${escapeShellArg (fileContents ./terranix-tests/07.nix.output)}
     }
 
     @test "strip-nulls: print nulls with --with-nulls" {
-    run ${terranix}/bin/terranix --with-nulls --quiet ${./terranix-tests/07.nix}
+    run ${terranix}/bin/terranix --with-nulls --quiet --pkgs ${nixpkgs} ${./terranix-tests/07.nix}
     assert_success
     assert_output  ${escapeShellArg (fileContents ./terranix-tests/07-nulls.nix.output)}
     }
@@ -61,18 +61,18 @@ with lib; [
 
   ''
     @test "magic-merge: works for attrs and lists" {
-    run ${terranix}/bin/terranix --quiet ${./terranix-tests/08-magic-merge.nix}
+    run ${terranix}/bin/terranix --quiet --pkgs ${nixpkgs} ${./terranix-tests/08-magic-merge.nix}
     assert_success
     assert_output ${escapeShellArg (fileContents ./terranix-tests/08-magic-merge.nix.output)}
     }
 
     @test "magic-merge: fails for setting different types" {
-    run ${terranix}/bin/terranix --quiet ${./terranix-tests/09-magic-merge-fail.nix}
+    run ${terranix}/bin/terranix --quiet --pkgs ${nixpkgs} ${./terranix-tests/09-magic-merge-fail.nix}
     assert_failure
     }
 
     @test "magic-merge: leave empty sets untouched" {
-    run ${terranix}/bin/terranix --quiet ${./terranix-tests/10-empty-sets.nix}
+    run ${terranix}/bin/terranix --quiet --pkgs ${nixpkgs} ${./terranix-tests/10-empty-sets.nix}
     assert_success
     assert_output ${escapeShellArg (fileContents ./terranix-tests/10-empty-sets.nix.output)}
     }
@@ -80,7 +80,7 @@ with lib; [
 
   ''
     @test "empty resources: should be filtered out" {
-    run ${terranix}/bin/terranix --quiet ${./terranix-tests/11.nix}
+    run ${terranix}/bin/terranix --quiet --pkgs ${nixpkgs} ${./terranix-tests/11.nix}
     assert_success
     assert_output ${escapeShellArg (fileContents ./terranix-tests/11.nix.output)}
     }
@@ -89,14 +89,17 @@ with lib; [
   ''
     @test "terranix-doc-json: works with simple module" {
     run ${terranix}/bin/terranix-doc-json --quiet \
-    --path ${./terranix-doc-json-tests} \
+      --pkgs ${nixpkgs} \
+      --path ${./terranix-doc-json-tests} \
       ${./terranix-doc-json-tests}/01.nix
     assert_success
     assert_output ${escapeShellArg (fileContents ./terranix-doc-json-tests/01.nix.output)}
     }
 
     @test "terranix-doc-json: works with empty module" {
-    run ${terranix}/bin/terranix-doc-json --quiet ${./terranix-doc-json-tests/02.nix}
+    run ${terranix}/bin/terranix-doc-json --quiet \
+      --pkgs ${nixpkgs} \
+      ${./terranix-doc-json-tests/02.nix}
     assert_success
     assert_output ${escapeShellArg (fileContents ./terranix-doc-json-tests/02.nix.output)}
     }


### PR DESCRIPTION
On my system, one test fails:

```
 ✗ terranix-doc-json: works with simple module
   (from function `assert_output' in file /nix/store/wq1qq2yhaxldcq0ll9ms54zw789xpy5p-source/src/assert_output.bash, line 194,
    in test file /nix/store/9dnr0i46zj79qbqabh9bfp9n5s8pkaca-test, line 164)
     `assert_output '{"testing-terranix.enable":{"declarations":[{"channelPath":"/01.nix","path":"01.nix","url":"http://example.com/01.nix"}],"default":false,"description":"Whether to enable enable testing-terranix.","example":true,"loc":["testing-terranix","enable"],"readOnly":false,"type":"boolean"}}'' failed
   
   -- output differs --
   expected : {"testing-terranix.enable":{"declarations":[{"channelPath":"/01.nix","path":"01.nix","url":"http://example.com/01.nix"}],"default":false,"description":"Whether to enable enable testing-terranix.","example":true,"loc":["testing-terranix","enable"],"readOnly":false,"type":"boolean"}}
   actual   : {"testing-terranix.enable":{"declarations":[{"channelPath":"/01.nix","path":"01.nix","url":"http://example.com/01.nix"}],"default":{"_type":"literalExpression","text":"false"},"description":"Whether to enable enable testing-terranix.","example":{"_type":"literalExpression","text":"true"},"loc":["testing-terranix","enable"],"readOnly":false,"type":"boolean"}}
   --
```

I noticed that the test run uses my systems `nixpkgs`, not the `nixpkgs` defined in the repository `flake.lock`. This PR pins the `nixpkgs` used in tests, making sure test runs are consistent between systems.

The above problem is due to changes in the upstream nixpkgs, and should probably be taken into account in the future.