### PR TITLE
Add tfRef to lib available from within terranix modules

### DIFF
--- a/core/default.nix
+++ b/core/default.nix
@@ -40,12 +40,19 @@ let
           recursiveSanitized;
     };
 
+  # pkgs.lib extended with terranix-specific utils
+  lib' = lib.extend (self: super: {
+    # small helper funtion to make definiing terraform string references
+    # (ie. ${aws_instance.foo.id})
+    # easier, without having to perform the ugly escaping
+    tfRef = ref: "\${${ref}}";
+  });
+
   # evaluate given config.
   # also include all the default modules
   # https://github.com/NixOS/nixpkgs/blob/master/lib/modules.nix#L95
   evaluateConfiguration = configuration:
-    with lib;
-    evalModules {
+    lib'.evalModules {
       modules = [
         { imports = [ ./terraform-options.nix ../modules ]; }
         { _module.args = { inherit pkgs; }; }

--- a/tests/terranix-tests/12.nix
+++ b/tests/terranix-tests/12.nix
@@ -1,0 +1,7 @@
+{ lib, ... }:
+
+{
+  resource.foo.bar = {
+    a-reference = lib.tfRef "data.another-resource.id";
+  };
+}

--- a/tests/terranix-tests/12.nix.output
+++ b/tests/terranix-tests/12.nix.output
@@ -1,0 +1,9 @@
+{
+  "resource": {
+    "foo": {
+      "bar": {
+        "a-reference": "${data.another-resource.id}"
+      }
+    }
+  }
+}

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -87,6 +87,15 @@ with lib; [
   ''
 
   ''
+    @test "terranix lib: tfRef should be available and properly return a reference" {
+    run ${terranix}/bin/terranix --quiet ${./terranix-tests/12.nix}
+    assert_success
+    assert_output ${escapeShellArg (fileContents ./terranix-tests/12.nix.output)}
+
+    }
+  ''
+
+  ''
     @test "terranix-doc-json: works with simple module" {
     run ${terranix}/bin/terranix-doc-json --quiet \
     --path ${./terranix-doc-json-tests} \


### PR DESCRIPTION
This allows a nicer way to create terraform reference strings, without having to perform escaping:

```
{ lib, ... }:

{
  resource.foo.bar = {
    a-reference = lib.tfRef "data.another-resource.id";
  };
}
```