### PR TITLE
check in `.envrc`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ result
 *.tfstate.*
 
 result*
+
+.direnv


### PR DESCRIPTION
For `direnv`: https://direnv.net/

A.f.a.i.k. there is debate over whether `.envrc` should be checked-in or not. There are good reasons to reject this PR; i.e. a developer who uses `direnv` but who does not use Nix Flakes. The `.envrc` in this PR would be bad for that developer.