### PR TITLE
add terraform invocation wrapping

### DIFF
--- a/core/terraform-invocs.nix
+++ b/core/terraform-invocs.nix
@@ -13,7 +13,7 @@ in
 rec {
   scripts = {
     apply = mkTfScript "apply" "terraform apply";
-    destroy = mkTfScript "destoy" "terraform destroy";
+    destroy = mkTfScript "destroy" "terraform destroy";
   };
 
   apps = pkgs.lib.fix (self:

--- a/core/terraform-invocs.nix
+++ b/core/terraform-invocs.nix
@@ -1,0 +1,28 @@
+{ pkgs ? import <nixpkgs> { }, terraformConfiguration, terraform ? pkgs.terraform, ... }:
+let
+  mkTfScript = name: text: pkgs.writeShellApplication {
+    inherit name;
+    runtimeInputs = [ terraform ];
+    text = ''
+      ln -sf ${terraformConfiguration} config.tf.json
+      terraform init
+      ${text}
+    '';
+  };
+in
+rec {
+  scripts = {
+    apply = mkTfScript "apply" "terraform apply";
+    destroy = mkTfScript "destoy" "terraform destroy";
+  };
+
+  apps = pkgs.lib.fix (self:
+    (builtins.mapAttrs (_: script: { program = script; }) scripts)
+    // { default = self.apply; });
+
+  devShells.default = pkgs.mkShell {
+    buildInputs = scripts;
+  };
+}
+
+

--- a/core/terraform-invocs.nix
+++ b/core/terraform-invocs.nix
@@ -21,7 +21,7 @@ rec {
     // { default = self.apply; });
 
   devShells.default = pkgs.mkShell {
-    buildInputs = scripts;
+    buildInputs = builtins.attrValues scripts;
   };
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -178,6 +178,8 @@
                 ' > $out
           '';
 
+      lib.mkTerranixOutputs = import ./core/terraform-invocs.nix;
+
       # deprecated
       lib.buildTerranix = nixpkgs.lib.warn "buildTerranix will be removed in 3.0.0 use terranixConfiguration instead"
         ({ pkgs, terranix_config, ... }@terranix_args:


### PR DESCRIPTION
<!--
⚠️  Remember that pull requests should target the `develop` branch, not the `main` branch!
-->
This PR adds a helper function, `terranix.lib.mkTerranixOutputs`, to simplify how you'd declare `nix run .#apply` and `nix run .#destroy`.

- It takes a `terraformConfiguration` to create a symlink of the terraform of the configuration in the current directory
- It optionally takes a custom `terraform` derivation (useful for wrapping `terraform` invocations in environments with secret envvars, like shown in the documentation)

From this, it generates `apply` and `destroy` scripts with the logic above prepended, as well as corresponding `app` outputs as well as a `devShell` for optional added ergonomy (compare `apply` to `nix run .#apply`)

Sample usage:
```nix
inherit (inputs.terranix.lib.mkTerranixOutputs {
  inherit pkgs;
  terraform = pkgs.writeShellApplication {
    name = "terraform";
    runtimeInputs = with pkgs; [ terraform pass ];
    text = ''
      HCLOUD_TOKEN=$(pass hcloud_api_token) 
      export HCLOUD_TOKEN
      terraform "$@"
    '';
  };
  terraformConfiguration = inputs.terranix.lib.terranixConfiguration {
    inherit system;
    modules = [ ./config.nix ];
  };
}) apps devShells;
```
