### PR TITLE
fix: add float to sanitize

### DIFF
--- a/core/default.nix
+++ b/core/default.nix
@@ -17,6 +17,7 @@ let
     getAttr (typeOf configuration) {
       bool = configuration;
       int = configuration;
+      float = configuration;
       string = configuration;
       str = configuration;
       list = map sanitize configuration;


### PR DESCRIPTION
Otherwise code like this:
```
  locals = {
    example = 1.1;
  };
```

fails with
```
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'plan'
         whose name attribute is located at /nix/store/sqmn1ky3k66661h32djyjvsr8l99330z-source/pkgs/stdenv/generic/make-derivation.nix:336:7

       … while evaluating attribute 'text' of derivation 'plan'

         at /nix/store/sqmn1ky3k66661h32djyjvsr8l99330z-source/pkgs/build-support/trivial-builders/default.nix:102:16:

          101|       ({
          102|         inherit text executable checkPhase allowSubstitutes preferLocalBuild;
             |                ^
          103|         passAsFile = [ "text" ]

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: attribute 'float' missing
```