### PR TITLE
Fix documentation for flake-parts module

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -9,7 +9,7 @@
           options.terranix = {
 
             setDevShell = mkOption {
-              description = lib.mdDoc ''
+              description = ''
                 Whether to set default `devShell` or not. By default enabled.
                 You can disable this if you want to customize the `devShell` creation youself or otherwise
                 wanting to avoid output definition conflicts.
@@ -23,20 +23,20 @@
 
             terranixConfigurations = mkOption
               {
-                description = lib.mdDoc "A submodule of all terranix configurations.";
+                description = "A submodule of all terranix configurations.";
                 default = { };
                 type = types.attrsOf
                   (types.submodule ({ name, ... } @ submod: {
                     options = {
                       terraformWrapper = mkOption {
-                        description = lib.mdDoc ''
+                        description = ''
                           How to invoke terraform for this terranix configuration.
                         '';
                         default = { };
                         type = types.submodule {
                           options = {
                             extraRuntimeInputs = mkOption {
-                              description = lib.mdDoc ''
+                              description = ''
                                 Extra runtimeInputs for the terraform
                                 invocations.
                               '';
@@ -44,14 +44,14 @@
                               default = [ ];
                             };
                             prefixText = mkOption {
-                              description = lib.mdDoc ''
+                              description = ''
                                 Prefix text
                               '';
                               type = types.str;
                               default = "";
                             };
                             suffixText = mkOption {
-                              description = lib.mdDoc ''
+                              description = ''
                                 Suffix text
                               '';
                               type = types.str;
@@ -62,7 +62,7 @@
                       };
 
                       modules = mkOption {
-                        description = lib.mdDoc ''
+                        description = ''
                           Modules of the Terranix configuration.
                         '';
                         type = types.listOf types.path;
@@ -70,7 +70,7 @@
                       };
 
                       workdir = mkOption {
-                        description = lib.mdDoc ''
+                        description = ''
                           Working directory of the terranix configuration.
                           Defaults to submodule name.
                         '';
@@ -79,8 +79,8 @@
                       };
 
                       result = mkOption {
-                        description = lib.mdDoc ''
-                          A collection of useful read-only outputs by this configuration. 
+                        description = ''
+                          A collection of useful read-only outputs by this configuration.
                           For debugging or otherwise.
                         '';
                         default = { };
@@ -88,7 +88,7 @@
                         type = types.submodule {
                           options = {
                             terraformConfiguration = mkOption {
-                              description = lib.mdDoc ''
+                              description = ''
                                 The exposed Terranix configuration as created by lib.terranixConfiguration.
                               '';
                               default = inputs.terranix.lib.terranixConfiguration {
@@ -97,7 +97,7 @@
                               };
                             };
                             terraformWrapper = mkOption {
-                              description = lib.mdDoc ''
+                              description = ''
                                 The exposed, wrapped Terraform.
                               '';
                               default = pkgs.writeShellApplication {
@@ -114,7 +114,7 @@
                               type = types.package;
                             };
                             scripts = mkOption {
-                              description = lib.mdDoc ''
+                              description = ''
                                 The exposed Terraform scripts (apply, etc). `result.terraformWrapper` included for convenience.
                               '';
                               default =
@@ -144,16 +144,16 @@
                                 };
                             };
                             app = mkOption {
-                              description = lib.mdDoc ''
+                              description = ''
                                 The exposed default app. Made from `result.scripts.apply`.
 
                                 Yes, only a single app, and simply running it as `nix run .#foo` would yield
-                                a `terraform apply` for the config `foo`. 
-                                
-                                But then how does random terraform invocations like `nix run .#foo.destroy` work? 
+                                a `terraform apply` for the config `foo`.
+
+                                But then how does random terraform invocations like `nix run .#foo.destroy` work?
                                 It's actually still using the same app as before - you're still in the `apply`
                                 derivation, as strange as it sounds.
-                                
+
                                 The magic lies in the use of derivation `passthru` which (simplified) lets you namespace other
                                 derivations inside a main derivation. In other words, `nix run .#foo` runs the `apply` derivation named
                                 `foo` like normally. `nix run .#foo.destroy` runs the `destroy` script inside of the `apply` derivation.
@@ -172,12 +172,12 @@
                               };
                             };
                             devShell = mkOption {
-                              description = lib.mdDoc ''
+                              description = ''
                                 The exposed devShell.
 
                                 Note that you have to re-enter/ your devShell when your configuration changes!
                                 The invocation scripts will still target your old configuration otherwise.
-                                
+
                                 For those who want `devShell`-based access like
                                 ```sh
                                 $ nix develop .#foo

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -1,4 +1,4 @@
-{ inputs, lib, self, flake-parts-lib, ... }: with lib; {
+{ inputs, lib, flake-parts-lib, ... }: with lib; {
   options = {
     perSystem = flake-parts-lib.mkPerSystemOption
       ({ config, options, pkgs, inputs', system, ... }:
@@ -95,6 +95,7 @@
                                 inherit system;
                                 inherit (submod.config) modules;
                               };
+                              defaultText = "The final Terraform configuration JSON.";
                             };
                             terraformWrapper = mkOption {
                               description = ''
@@ -111,6 +112,7 @@
                                   ${submod.config.terraformWrapper.suffixText}
                                 '';
                               };
+                              defaultText = "The Terraform wrapper.";
                               type = types.package;
                             };
                             scripts = mkOption {
@@ -142,6 +144,26 @@
                                   '';
                                   terraform = submod.config.result.terraformWrapper;
                                 };
+                              defaultText = ''
+                                {
+                                  init = mkTfScript "init" '''
+                                    terraform init
+                                  ''';
+                                  apply = mkTfScript "apply" '''
+                                    terraform init
+                                    terraform apply
+                                  ''';
+                                  plan = mkTfScript "plan" '''
+                                    terraform init
+                                    terraform plan
+                                  ''';
+                                  destroy = mkTfScript "destroy" '''
+                                    terraform init
+                                    terraform destroy
+                                  ''';
+                                  terraform = submod.config.result.terraformWrapper;
+                                }
+                              '';
                             };
                             app = mkOption {
                               description = ''
@@ -170,6 +192,7 @@
                                 inherit name;
                                 passthru = submod.config.result.scripts;
                               };
+                              defaultText = "The default app which defaults to the `apply` script.";
                             };
                             devShell = mkOption {
                               description = ''
@@ -196,6 +219,7 @@
                                   (builtins.attrValues submod.config.result.scripts)
                                   ++ [ submod.config.result.terraformWrapper ];
                               };
+                              defaultText = "The final devShell with scripts and terraform wrapper.";
                             };
                           };
                         };

--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
 
       flake = {
 
-        flakeModule = import ./flake-module.nix;
+        flakeModule = ./flake-module.nix;
 
         # terraformConfiguration ast, if you want to run
         # terranix in the repl.


### PR DESCRIPTION
This allows the terranix flake-parts options to show up on https://flake.parts/

I've intentionally targeted the `main` branch as I don't believe there are any breaking changes here and will allow [flake.parts-website](https://github.com/hercules-ci/flake.parts-website) to use this code earlier

<details><summary>Rendered</summary>

# terranix


[terranix](https://terranix.org/) is a terraform.json generator with a nix-like feeling.


## Installation

To use these options, add to your flake inputs:

```nix
terranix.url = "github:terranix/terranix";
```

and inside the `mkFlake`:


```nix
imports = [
  inputs.terranix.flakeModule
];
```

Run `nix flake lock` and you're set.

## Options

## perSystem\.terranix\.setDevShell {#opt-perSystem.terranix.setDevShell}

Whether to set default ` devShell ` or not\. By default enabled\.
You can disable this if you want to customize the ` devShell ` creation youself or otherwise
wanting to avoid output definition conflicts\.

The devShell are still available at ` terranix.terranixConfigurations.<name>.result.devShell `, should
you want to incorporate them using ` pkgs.mkShell.inputsFrom ` or similar\.



*Type:*
boolean



*Default:*
` true `

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations {#opt-perSystem.terranix.terranixConfigurations}



A submodule of all terranix configurations\.



*Type:*
attribute set of (submodule)



*Default:*
` { } `

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations\.\<name>\.modules {#opt-perSystem.terranix.terranixConfigurations._name_.modules}



Modules of the Terranix configuration\.



*Type:*
list of path



*Default:*
` [ ] `

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations\.\<name>\.result {#opt-perSystem.terranix.terranixConfigurations._name_.result}



A collection of useful read-only outputs by this configuration\.
For debugging or otherwise\.



*Type:*
submodule *(read only)*



*Default:*
` { } `

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations\.\<name>\.result\.app {#opt-perSystem.terranix.terranixConfigurations._name_.result.app}



The exposed default app\. Made from ` result.scripts.apply `\.

Yes, only a single app, and simply running it as ` nix run .#foo ` would yield
a ` terraform apply ` for the config ` foo `\.

But then how does random terraform invocations like ` nix run .#foo.destroy ` work?
It’s actually still using the same app as before - you’re still in the ` apply `
derivation, as strange as it sounds\.

The magic lies in the use of derivation ` passthru ` which (simplified) lets you namespace other
derivations inside a main derivation\. In other words, ` nix run .#foo ` runs the ` apply ` derivation named
` foo ` like normally\. ` nix run .#foo.destroy ` runs the ` destroy ` script inside of the ` apply ` derivation\.

This workaround is required because the flake schema outputs have no concept of nesting derivations like this -
i\.e\. ` apps.x86_64-linux.foo ` HAS to resolve to a derivation and NOT an attrset\.

The ` legacyPackages ` output is an exception to this rule\.
It was created because ` nixpkgs ` constantly nest derivations (consider package sets like ` python311Packages `),
so an escape hatch was needed for flakes who needed to refer to these nested derivations\.
But having scripts reside in this output made no semantic sense, so this was done instead as a conceptual simplication\.



*Type:*
unspecified value



*Default:*
`` "The default app which defaults to the `apply` script." ``

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations\.\<name>\.result\.devShell {#opt-perSystem.terranix.terranixConfigurations._name_.result.devShell}



The exposed devShell\.

Note that you have to re-enter/ your devShell when your configuration changes!
The invocation scripts will still target your old configuration otherwise\.

For those who want ` devShell `-based access like

```sh
$ nix develop .#foo
$ apply
$ destroy

```

As opposed to ` app `-based access like

```
$ nix run .#foo
$ nix run .#foo.destroy
```



*Type:*
unspecified value



*Default:*
` "The final devShell with scripts and terraform wrapper." `

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations\.\<name>\.result\.scripts {#opt-perSystem.terranix.terranixConfigurations._name_.result.scripts}



The exposed Terraform scripts (apply, etc)\. ` result.terraformWrapper ` included for convenience\.



*Type:*
unspecified value



*Default:*

```
''
  {
    init = mkTfScript "init" '''
      terraform init
    ''';
    apply = mkTfScript "apply" '''
      terraform init
      terraform apply
    ''';
    plan = mkTfScript "plan" '''
      terraform init
      terraform plan
    ''';
    destroy = mkTfScript "destroy" '''
      terraform init
      terraform destroy
    ''';
    terraform = submod.config.result.terraformWrapper;
  }
''
```

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations\.\<name>\.result\.terraformConfiguration {#opt-perSystem.terranix.terranixConfigurations._name_.result.terraformConfiguration}



The exposed Terranix configuration as created by lib\.terranixConfiguration\.



*Type:*
unspecified value



*Default:*
` "The final Terraform configuration JSON." `

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations\.\<name>\.result\.terraformWrapper {#opt-perSystem.terranix.terranixConfigurations._name_.result.terraformWrapper}



The exposed, wrapped Terraform\.



*Type:*
package



*Default:*
` "The Terraform wrapper." `

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations\.\<name>\.terraformWrapper {#opt-perSystem.terranix.terranixConfigurations._name_.terraformWrapper}



How to invoke terraform for this terranix configuration\.



*Type:*
submodule



*Default:*
` { } `

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations\.\<name>\.terraformWrapper\.extraRuntimeInputs {#opt-perSystem.terranix.terranixConfigurations._name_.terraformWrapper.extraRuntimeInputs}



Extra runtimeInputs for the terraform
invocations\.



*Type:*
list of package



*Default:*
` [ ] `

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations\.\<name>\.terraformWrapper\.prefixText {#opt-perSystem.terranix.terranixConfigurations._name_.terraformWrapper.prefixText}



Prefix text



*Type:*
string



*Default:*
` "" `

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations\.\<name>\.terraformWrapper\.suffixText {#opt-perSystem.terranix.terranixConfigurations._name_.terraformWrapper.suffixText}



Suffix text



*Type:*
string



*Default:*
` "" `

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)



## perSystem\.terranix\.terranixConfigurations\.\<name>\.workdir {#opt-perSystem.terranix.terranixConfigurations._name_.workdir}



Working directory of the terranix configuration\.
Defaults to submodule name\.



*Type:*
string



*Default:*
` "‹name›" `

*Declared by:*
 - [terranix/flake-module\.nix](https://github.com/terranix/terranix/blob/main/flake-module.nix)
</details>

```
$ nix build github:hercules-ci/flake.parts-website/pull/1278/head#generated-docs-terranix --override-input terranix .
```