### PR TITLE
:memo: update matrix channel name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > This project is not active maintained.
-> If you are interested in becoming a maintainer, please contact us at [#terranix:terranix.org](https://matrix.to/#/!p1L9bP3SdzBoIhan:terranix.org?via=thalheim.io&via=matrix.org&via=nixos.dev)
+> If you are interested in becoming a maintainer, please contact us at [#terranix:nixos.org](https://matrix.to/#/!p1L9bP3SdzBoIhan:terranix.org?via=thalheim.io&via=matrix.org&via=nixos.dev)
 
 A NixOS way to create `terraform.json` files.
 
@@ -24,7 +24,7 @@ They live in
 
 # Community
 
-Join us at the `#terranix:terranix.org` matrix channel.
+Join us at the `#terranix:nixos.org` matrix channel.
 
 # See also
 


### PR DESCRIPTION
There doesn't seem to be a Matrix server at terranix.org anymore and the room's address has been updated to #terranix:nixos.org. So while clicking the link works, copying the address to a matrix client does not.

Also: I tried to contact you in that room regarding maintenance.