### PR TITLE
fix: Ensure workspace exists in flake-parts module scripts

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -139,6 +139,7 @@
                                     inherit name;
                                     runtimeInputs = [ submod.config.result.terraformWrapper ];
                                     text = ''
+                                      mkdir -p ${submod.config.workdir}
                                       ln -sf ${submod.config.result.terraformConfiguration} ${submod.config.workdir}/config.tf.json
                                       ${text}
                                     '';


### PR DESCRIPTION
Within the terraform wrapper we ensure the directory is created, however the `ln` happens before that. Ensure the workdir exists before linking the tf json.