### PR TITLE
refactor: separate dev inputs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,1 @@
-export NIXPKGS_ALLOW_UNFREE=1
-use flake --impure
+use flake

--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -1,0 +1,70 @@
+{ inputs, ... }:
+
+{
+  perSystem =
+    { config
+    , pkgs
+    , ...
+    }:
+    {
+      devShells.default = pkgs.mkShell {
+        buildInputs = with pkgs;
+          [
+            terraform
+            config.packages.terranix
+            treefmt
+            nixpkgs-fmt
+            shfmt
+            shellcheck
+            nodePackages.prettier
+          ];
+      };
+
+      apps = rec {
+        test.program = pkgs.writeShellApplication {
+          name = "test";
+          runtimeInputs = with pkgs; [ boxes bats ];
+          text =
+            let
+              tests = import ../tests/test.nix {
+                inherit (inputs) nixpkgs;
+                inherit (inputs.nixpkgs) lib;
+                inherit pkgs;
+                terranix = config.packages.terranix;
+              };
+              testFile = pkgs.writeText "test" ''
+                load '${inputs.bats-support}/load.bash'
+                load '${inputs.bats-assert}/load.bash'
+                ${pkgs.lib.concatStringsSep "\n" tests}
+              '';
+            in
+            ''
+              echo "running terranix tests" | boxes -d ian_jones -a c
+              #cat ${testFile}
+              bats ${testFile}
+            '';
+        };
+
+        # nix run ".#docs"
+        doc = docs;
+        docs.program = pkgs.writeShellApplication {
+          name = "docs";
+          runtimeInputs = with pkgs; [ pandoc gnumake nix ];
+          text = ''
+            make --always-make --directory=doc
+            nix build ".#manpages"
+            cp -r result/share .
+            chmod -R 755 ./share
+            rm result
+          '';
+        };
+      };
+
+      formatter = pkgs.treefmt;
+    };
+
+  # nix flake init -t github:terranix/terranix#flake
+  flake.templates = inputs.terranix-examples.templates // {
+    default = inputs.terranix-examples.defaultTemplate;
+  };
+}

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "bats-assert": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1742639935,
+        "narHash": "sha256-5xHWCp7fnM/UfFDQoQ03AVVevlidsenZw30eDAHtTQ8=",
+        "owner": "bats-core",
+        "repo": "bats-assert",
+        "rev": "b93143a1bfbde41d9b7343aab0d36f3ef6549e6b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bats-core",
+        "repo": "bats-assert",
+        "type": "github"
+      }
+    },
+    "bats-support": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1742420943,
+        "narHash": "sha256-cB26cPwwhR/aJ1mcdixzn7018Axuz744djMQI4ePMLc=",
+        "owner": "bats-core",
+        "repo": "bats-support",
+        "rev": "d007fc1f451abbad55204fa9c9eb3e6ed5dc5f61",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bats-core",
+        "repo": "bats-support",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "bats-assert": "bats-assert",
+        "bats-support": "bats-support",
+        "terranix-examples": "terranix-examples"
+      }
+    },
+    "terranix-examples": {
+      "locked": {
+        "lastModified": 1637156952,
+        "narHash": "sha256-KqvXIe1yiKOEP9BRYqNQN+LOWPCsWojh0WjEgv5jfEI=",
+        "owner": "terranix",
+        "repo": "terranix-examples",
+        "rev": "921680efb8af0f332d8ad73718d53907f9483e24",
+        "type": "github"
+      },
+      "original": {
+        "owner": "terranix",
+        "repo": "terranix-examples",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "Dependencies for development purposes";
+
+  inputs = {
+    terranix-examples.url = "github:terranix/terranix-examples";
+
+    bats-support = {
+      url = "github:bats-core/bats-support";
+      flake = false;
+    };
+
+    bats-assert = {
+      url = "github:bats-core/bats-assert";
+      flake = false;
+    };
+  };
+
+  outputs = _: { };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,37 +1,5 @@
 {
   "nodes": {
-    "bats-assert": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1692829535,
-        "narHash": "sha256-oDqhUQ6Xg7a3xx537SWLGRzqP3oKKeyY4UYGCdz9z/Y=",
-        "owner": "bats-core",
-        "repo": "bats-assert",
-        "rev": "e2d855bc78619ee15b0c702b5c30fb074101159f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "bats-core",
-        "repo": "bats-assert",
-        "type": "github"
-      }
-    },
-    "bats-support": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1693050811,
-        "narHash": "sha256-PxJaH16+QrsfZqtkWVt5K6TwJB5gjIXnbGo+MB84WIU=",
-        "owner": "bats-core",
-        "repo": "bats-support",
-        "rev": "9bf10e876dd6b624fe44423f0b35e064225f7556",
-        "type": "github"
-      },
-      "original": {
-        "owner": "bats-core",
-        "repo": "bats-support",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -69,12 +37,9 @@
     },
     "root": {
       "inputs": {
-        "bats-assert": "bats-assert",
-        "bats-support": "bats-support",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "systems": "systems",
-        "terranix-examples": "terranix-examples"
+        "systems": "systems"
       }
     },
     "systems": {
@@ -89,21 +54,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "terranix-examples": {
-      "locked": {
-        "lastModified": 1637156952,
-        "narHash": "sha256-KqvXIe1yiKOEP9BRYqNQN+LOWPCsWojh0WjEgv5jfEI=",
-        "owner": "terranix",
-        "repo": "terranix-examples",
-        "rev": "921680efb8af0f332d8ad73718d53907f9483e24",
-        "type": "github"
-      },
-      "original": {
-        "owner": "terranix",
-        "repo": "terranix-examples",
         "type": "github"
       }
     }


### PR DESCRIPTION
This is using the flake-parts feature partitions in order to move inputs not needed by third-party consumers into a separate dev flake.

This reduces the amount of inputs that gets inherited by downstream users.