### PR TITLE
flake-parts: Fix documentation eval

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -33,7 +33,7 @@
                       terraformWrapper = {
                         package = mkPackageOption pkgs "terraform" {
                           example = "pkgs.opentofu";
-                          description = ''
+                          extraDescription = ''
                             Specifies which Terraform implementation you want to use.
 
                             You may also specify which plugins you want to use with your Terraform implementation:


### PR DESCRIPTION
Fixes the following error, so docs can be published on flake.parts again.

```
       … from call site
         at /nix/store/ri9gj1alzk2apqfvrvzx6p6m6r5n52sx-source/flake-module.nix:34:35:
           33|                       terraformWrapper = {
           34|                         package = mkPackageOption pkgs "terraform" {
             |                                   ^
           35|                           example = "pkgs.opentofu";

       error: function 'mkPackageOption' called with unexpected argument 'description'
       at /nix/store/80jiav8nl8hsx2sf4miaihfacajn1i5h-source/lib/options.nix:311:7:
          310|       name:
          311|       {
             |       ^
          312|         nullable ? false,
```