### PR TITLE
Implement escapeEscape helpers

### DIFF
--- a/core/helpers.nix
+++ b/core/helpers.nix
@@ -1,7 +1,7 @@
 # override to the standard nixpkgs lib, adding
 # terranix-related helpers
 pkgs: self: super: {
-  tf = {
+  tf = rec {
     # escape ${} to create a terraform reference string
     ref = ref: "\${${ref}}";
 
@@ -20,6 +20,38 @@ pkgs: self: super: {
             else source;
         in
         "templatefile(\"${template}\", ${builtins.toJSON variables})";
+
+    # Apply function to all strings in an attrset recursively through lists as well
+    # Converts stringlike types to string before (derivations become paths for example)
+    mapStringsDeep =
+      function: value:
+      if super.isStringLike value then
+        function (toString value)
+      else if super.isAttrs value then
+        super.mapAttrs (name: mapStringsDeep function) value
+      else if super.isList value then
+        map (mapStringsDeep function) value
+      else
+        value;
+
+    # Escapes strings so variables aren't interpolated with ${} and %{}
+    escapeInterpolation =
+      value:
+      super.replaceStrings
+        [
+          # Nix and tf shares this escape pattern
+          "\${"
+          # tf also interpolates %{}
+          "%{"
+        ]
+        [
+          "$\${"
+          "%%{"
+        ]
+        value;
+
+    # Escape all strings in an attrset so tf can parse it properly
+    escapeInterpolationDeep = attrs: mapStringsDeep escapeInterpolation attrs;
   };
 
   # top-level aliases for backwards compatibility


### PR DESCRIPTION
Implements functions that escapes Terraform escape codes so that they're interpreted as strings when parsed through config.tf.json. This includes mapStringsDeep which applies a function on all strings in an attrset recursively through both attrsets and lists. It also applies toString to any stringlike type so it can be used by Terraform.

Escapes both ${} and %{} for consistency.

Discussion: I think traversing resources, locals and data and applying toString recursively to any stringlike type might make sense, that way if you stick derivations into values they're turned into storepaths automatically, or is it too much magic?

However what's in the PR is something I'm using right now to apply k8s JSON from kubenix through the TF kubectl provider (Cilium CNI has ${BIN_PATH} in some argument list somewhere) and I don't have a hole in my foot yet.

The formatting changes are nixfmt-rfc-style, I added rec since mapStringsDep calls itself but I could move it to a let block, doesn't look like it'll hurt here though tbf.

TODO: Docs?