### PR TITLE
fix(flake-parts): Do not require terranix to be in root of inputs

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -1,3 +1,4 @@
+{ terranix }:
 { inputs, lib, flake-parts-lib, ... }: with lib; {
   options = {
     perSystem = flake-parts-lib.mkPerSystemOption
@@ -107,7 +108,7 @@
                               description = ''
                                 The exposed Terranix configuration as created by lib.terranixConfiguration.
                               '';
-                              default = inputs.terranix.lib.terranixConfiguration {
+                              default = terranix.lib.terranixConfiguration {
                                 inherit system;
                                 inherit (submod.config) extraArgs modules;
                               };
@@ -149,7 +150,8 @@
                                 in
                                 let
                                   tfBinaryName = submod.config.result.terraformWrapper.meta.mainProgram;
-                                in {
+                                in
+                                {
                                   init = mkTfScript "init" ''
                                     ${tfBinaryName} init
                                   '';

--- a/flake.nix
+++ b/flake.nix
@@ -14,9 +14,9 @@
 
   outputs = inputs @ { self, flake-parts, nixpkgs, ... }:
 
-    flake-parts.lib.mkFlake { inherit inputs; } {
+    flake-parts.lib.mkFlake { inherit inputs; } ({ flake-parts-lib, ... }: {
       imports = [
-        ./flake-module.nix
+        (flake-parts-lib.importApply ./flake-module.nix { terranix = self; })
         flake-parts.flakeModules.partitions
       ];
 
@@ -60,7 +60,7 @@
 
       flake = {
 
-        flakeModule = ./flake-module.nix;
+        flakeModule = (flake-parts-lib.importApply ./flake-module.nix { terranix = self; });
 
         # terraformConfiguration ast, if you want to run
         # terranix in the repl.
@@ -187,5 +187,5 @@
                 '';
               });
       };
-    };
+    });
 }


### PR DESCRIPTION
This change removes the reference to `inputs.terranix` used in the flake module, so the module can be used also in flake-parts based flakes that do not import terranix directly, but only as a transitive dependency.

Now it is irelevant, where the terranix flake resides in inputs, whether it is at `inputs.terranix` (as required now) or e.g. as `inputs.some-flake.inputs.terranix.