### PR TITLE
flake-parts: Separate `apps` from `packages` output

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -255,16 +255,15 @@
           };
 
           config = {
-            packages = (lib.mapAttrs (_: tnixConfig: tnixConfig.result.app) cfg.terranixConfigurations) // (
+            packages = lib.mapAttrs (_: tnixConfig: tnixConfig.result.app) cfg.terranixConfigurations;
+            apps =
               lib.optionalAttrs
                 (cfg.terranixConfigurations ? "default")
 
                 (builtins.mapAttrs
                   (_: script: { program = script; })
                   cfg.terranixConfigurations.default.result.scripts
-                )
-            );
-
+                );
             devShells = mkIf cfg.exportDevShells (builtins.mapAttrs
               (_: tnixConfig: tnixConfig.result.devShell)
               cfg.terranixConfigurations);


### PR DESCRIPTION
When `terranixConfigurations.default` exists, the scripts were erroneously being set to `packages` flake output instead of `apps`