### PR TITLE
lib: expose `config` from `terranixConfiguration`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Deprecate `terranixConfigurationAst`
 - Expose `config` from `terranixConfiguration`
 - Fix docs generation (#134)
 - flake-parts: Separate `apps` from `packages` output (#133)

--- a/flake.nix
+++ b/flake.nix
@@ -64,17 +64,9 @@
 
         # terraformConfiguration ast, if you want to run
         # terranix in the repl.
-        lib.terranixConfigurationAst =
-          { system ? ""
-          , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
-          , extraArgs ? { }
-          , modules ? [ ]
-          , strip_nulls ? true
-          }:
-          import ./core/default.nix {
-            inherit pkgs extraArgs strip_nulls;
-            terranix_config.imports = modules;
-          };
+        lib.terranixConfigurationAst = args:
+          nixpkgs.lib.warn "terranixConfigurationAst will be removed in 3.0.0 use terranixConfiguration.config instead"
+          (self.lib.terranixConfiguration args);
 
         # terranixOptions ast, if you want to run
         # terranix in a repl.


### PR DESCRIPTION
This allows users to access `config` through `(terranix.lib.terranixConfiguration { ... }).config`