### PR TITLE
Expose core module evaluation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- Add `lib.evalTerranixConfiguration` for evaluating terranix modules without creating a derivation
+- Refactor core to use `modules` list parameter instead of `terranix_config`
+- Fix `bin/terranix` CLI to use updated core interface
+- Fix test stderr warnings polluting output comparisons
 - Deprecate `terranixConfigurationAst`
 - Expose `config` from `terranixConfiguration`
 - Fix docs generation (#134)

--- a/bin/terranix
+++ b/bin/terranix
@@ -80,7 +80,7 @@ let
   pkgs = import $PKGS {};
   terranixCore = import $DEFAULT_CONFIG {
     inherit pkgs;
-    terranix_config = { imports = [ <config> ]; };
+    modules = [ <config> ];
     strip_nulls = $STRIP_NULLS;
   };
 in

--- a/core/toplevel.nix
+++ b/core/toplevel.nix
@@ -2,7 +2,7 @@
 
 let
   configuration = import ./default.nix {
-    terranix_config = { imports = [ <config> ]; };
+    modules = { imports = [ <config> ]; };
   };
 in
 

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -28,7 +28,7 @@ let
   terranix-doc-json-test-template = { text, path ? "", file, options ? [ ], success ? true, outputFile ? "", ... }:
     ''
       @test "${text}" {
-      run ${terranix}/bin/terranix-doc-json --quiet ${optionalString (path != "") "--path ${path}"} ${concatStringsSep " " options} --pkgs ${nixpkgs} --quiet ${file}
+      run bash -c '${terranix}/bin/terranix-doc-json --quiet ${optionalString (path != "") "--path ${path}"} ${concatStringsSep " " options} --pkgs ${nixpkgs} --quiet ${file} 2>/dev/null'
       ${if success then "assert_success" else "assert_failure"}
       ${optionalString (outputFile != "") "assert_output ${escapeShellArg (fileContents outputFile)}"}
       }


### PR DESCRIPTION
`lib.evalTerranix` decouples the core module evaluation from `terranixConfiguration`. I think this is cleaner in many cases than accessing through the passthru config and more flexibly selects a default `pkgs`.