### PR TITLE
fix(core/terraform-invocs): Use meta.mainProgram instead of hardcoded terraform binary

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix(core/terraform-invocs): Use meta.mainProgram instead of hardcoded terraform binary (#156)
 - chore: Add changelog check on CI (#141)
 - Add `lib.evalTerranixConfiguration` for evaluating terranix modules without creating a derivation
 - Refactor core to use `modules` list parameter instead of `terranix_config`

--- a/core/terraform-invocs.nix
+++ b/core/terraform-invocs.nix
@@ -1,12 +1,14 @@
 { pkgs ? import <nixpkgs> { }, terraformConfiguration, terraformWrapper ? null, prefixText ? "" }:
 let
   wrapper =
+    # Use wrapper attrset
     if terraformWrapper ? package then {
-      inherit (terraformWrapper) package;
+      package = terraformWrapper.package;
       extraRuntimeInputs = terraformWrapper.extraRuntimeInputs or [];
       prefixText = terraformWrapper.prefixText or "";
       suffixText = terraformWrapper.suffixText or "";
     }
+    # Assume this is pkgs.terraform, pkgs.opentofu or other package derivation
     else {
       package = if terraformWrapper == null then pkgs.terraform else terraformWrapper;
       extraRuntimeInputs = [];

--- a/core/terraform-invocs.nix
+++ b/core/terraform-invocs.nix
@@ -12,7 +12,7 @@ let
     else {
       package = if terraformWrapper == null then pkgs.terraform else terraformWrapper;
       extraRuntimeInputs = [];
-      inherit prefixText;
+      prefixText = prefixText;
       suffixText = "";
     };
 

--- a/core/terraform-invocs.nix
+++ b/core/terraform-invocs.nix
@@ -1,20 +1,14 @@
 { pkgs ? import <nixpkgs> { }, terraformConfiguration, terraformWrapper ? null, prefixText ? "" }:
 let
   wrapper =
-    if terraformWrapper == null then {
-      package = pkgs.terraform;
-      extraRuntimeInputs = [];
-      inherit prefixText;
-      suffixText = "";
-    }
-    else if terraformWrapper ? package then {
+    if terraformWrapper ? package then {
       inherit (terraformWrapper) package;
       extraRuntimeInputs = terraformWrapper.extraRuntimeInputs or [];
       prefixText = terraformWrapper.prefixText or "";
       suffixText = terraformWrapper.suffixText or "";
     }
     else {
-      package = terraformWrapper;
+      package = if terraformWrapper == null then pkgs.terraform else terraformWrapper;
       extraRuntimeInputs = [];
       inherit prefixText;
       suffixText = "";

--- a/dev/flake-module-checks.nix
+++ b/dev/flake-module-checks.nix
@@ -1,0 +1,80 @@
+{
+  perSystem =
+    { pkgs
+    , ...
+    }:
+    {
+      checks =
+        let
+          mockTerraformConfiguration = pkgs.writeText "config.tf.json" "{}";
+
+          mkMockTfPackage = name: pkgs.writeShellApplication {
+            inherit name;
+            text = ''echo "mock ${name} $*"'';
+          } // { meta.mainProgram = name; };
+
+          mockTerraform = mkMockTfPackage "mock-terraform";
+
+          legacyWrapper = import ../core/terraform-invocs.nix;
+
+          assertScriptContains = checkName: script: expected:
+            pkgs.runCommand checkName { } ''
+              scriptText=$(cat ${script}/bin/*)
+              for pattern in ${builtins.concatStringsSep " " (map (s: "'${s}'") expected)}; do
+                if ! echo "$scriptText" | grep -qF "$pattern"; then
+                  echo "FAIL: expected '$pattern' in script"
+                  echo "Script contents:"
+                  echo "$scriptText"
+                  exit 1
+                fi
+              done
+              echo "PASS: ${checkName}" > $out
+            '';
+        in
+        {
+          legacy-wrapper-raw-package =
+            let
+              result = legacyWrapper {
+                inherit pkgs;
+                terraformConfiguration = mockTerraformConfiguration;
+                terraformWrapper = mockTerraform;
+              };
+            in
+            assertScriptContains "legacy-wrapper-raw-package" result.scripts.apply [
+              "mock-terraform init"
+              "mock-terraform apply"
+            ];
+
+          legacy-wrapper-attrset =
+            let
+              result = legacyWrapper {
+                inherit pkgs;
+                terraformConfiguration = mockTerraformConfiguration;
+                terraformWrapper = {
+                  package = mockTerraform;
+                  prefixText = "echo test-prefix";
+                  suffixText = "echo test-suffix";
+                };
+              };
+            in
+            assertScriptContains "legacy-wrapper-attrset" result.scripts.apply [
+              "mock-terraform init"
+              "mock-terraform apply"
+              "echo test-prefix"
+              "echo test-suffix"
+            ];
+
+          legacy-wrapper-default =
+            let
+              result = legacyWrapper {
+                inherit pkgs;
+                terraformConfiguration = mockTerraformConfiguration;
+              };
+            in
+            assertScriptContains "legacy-wrapper-default" result.scripts.apply [
+              "terraform init"
+              "terraform apply"
+            ];
+        };
+    };
+}

--- a/dev/flake-module-checks.nix
+++ b/dev/flake-module-checks.nix
@@ -66,9 +66,11 @@
 
           legacy-wrapper-default =
             let
+              mockDefault = mkMockTfPackage "terraform";
               result = legacyWrapper {
                 inherit pkgs;
                 terraformConfiguration = mockTerraformConfiguration;
+                terraformWrapper = mockDefault;
               };
             in
             assertScriptContains "legacy-wrapper-default" result.scripts.apply [

--- a/flake.nix
+++ b/flake.nix
@@ -25,11 +25,15 @@
 
       partitions.dev = {
         extraInputsFlake = ./dev;
-        module.imports = [ ./dev/flake-module.nix ];
+        module.imports = [
+          ./dev/flake-module.nix
+          ./dev/flake-module-checks.nix
+        ];
       };
 
       partitionedAttrs = {
         apps = "dev";
+        checks = "dev";
         devShells = "dev";
         formatter = "dev";
         templates = "dev";


### PR DESCRIPTION
The non-flake `mkTerranixOutputs` API hardcoded "terraform" in generated scripts, breaking usage with pkgs.opentofu. Now derives the binary name from the package's `meta.mainProgram`.

Also accept `terraformWrapper` as either a raw package or an attrset with

```nix
{
  package,
  extraRuntimeInputs,
  prefixText,
  suffixText,
}
```

matching the [flake-module pattern](https://terranix.org/terranix-and-flake-modules.html). Add flake checks to verify both forms.