### PR TITLE
Add `moved`/`removed` blocks to syntax

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat: add `.moved` and `.removed` keywords
 - chore: Add changelog check on CI (#141)
 - Add `lib.evalTerranixConfiguration` for evaluating terranix modules without creating a derivation
 - Add internal `_meta` passthru to `lib.evalTerranixConfiguration`

--- a/bin/terranix-doc-json
+++ b/bin/terranix-doc-json
@@ -113,10 +113,12 @@ then
       del(.import) |
       del(.locals) |
       del(.module) |
+      del(.moved) |
       del(."_module.args") |
       del(.output) |
       del(.provider) |
       del(.resource) |
+      del(.removed) |
       del(.terraform) |
       del(.variable)'
 fi

--- a/core/default.nix
+++ b/core/default.nix
@@ -84,6 +84,7 @@ let
         (whitelist "module") //
         (whitelist "output") //
         (whitelist "provider") //
+        (whitelist "removed") //
         (whitelistWithoutEmpty "resource") //
         (whitelist "terraform") //
         (whitelist "variable");

--- a/core/default.nix
+++ b/core/default.nix
@@ -82,6 +82,7 @@ let
         (whitelist "import") //
         (whitelist "locals") //
         (whitelist "module") //
+        (whitelist "moved") //
         (whitelist "output") //
         (whitelist "provider") //
         (whitelist "removed") //

--- a/core/terraform-options.nix
+++ b/core/terraform-options.nix
@@ -119,7 +119,7 @@ in
       };
       description = ''
         Define terraform import.
-        See for mote details : https://developer.hashicorp.com/terraform/language/import
+        See for more details : https://developer.hashicorp.com/terraform/language/import
       '';
     };
     module = mkMagicMergeOption {
@@ -134,6 +134,20 @@ in
         The terraform module system, and has nothing to
         do with the module system of terranix or nixos.
         See for more details : https://www.terraform.io/docs/configuration/modules.html
+      '';
+    };
+    moved = mkMagicMergeOption {
+      example = {
+        moved = [
+          {
+            from = "aws_instance.example";
+            to = "aws_instance.other_example";
+          }
+        ];
+      };
+      description = ''
+        Move a resource from one address to another.
+        See for more details : https://developer.hashicorp.com/terraform/language/block/moved
       '';
     };
     output = mkMagicMergeOption {
@@ -171,7 +185,7 @@ in
       };
       description = ''
         Define a removed resource.
-        See for mote details : https://developer.hashicorp.com/terraform/language/state/remove
+        See for more details : https://developer.hashicorp.com/terraform/language/state/remove
       '';
     };
     resource = mkReferenceableOption {

--- a/core/terraform-options.nix
+++ b/core/terraform-options.nix
@@ -160,6 +160,20 @@ in
         or https://www.terraform.io/docs/providers/index.html
       '';
     };
+    removed = mkMagicMergeOption {
+      example = {
+        removed = [
+          {
+            from = "aws_instance.example";
+            lifecycle.destroy = false;
+          }
+        ];
+      };
+      description = ''
+        Define a removed resource.
+        See for mote details : https://developer.hashicorp.com/terraform/language/state/remove
+      '';
+    };
     resource = mkReferenceableOption {
       example = {
         resource.aws_instance.web = {

--- a/flake.nix
+++ b/flake.nix
@@ -142,8 +142,10 @@
                   del(.import) |
                   del(.locals) |
                   del(.module) |
+                  del(.moved) |
                   del(.output) |
                   del(.provider) |
+                  del(.removed) |
                   del(.resource) |
                   del(.terraform) |
                   del(.variable)
@@ -185,9 +187,11 @@
                       del(.import) |
                       del(.locals) |
                       del(.module) |
+                      del(.moved) |
                       del(.output) |
                       del(.provider) |
                       del(.resource) |
+                      del(.removed) |
                       del(.terraform) |
                       del(.variable)
                       ' > $out/options.json


### PR DESCRIPTION
Per the documentation, we should be able to add [moved](https://developer.hashicorp.com/terraform/language/block/moved) and [removed](https://developer.hashicorp.com/terraform/language/state/remove) blocks to refactor state.

I basically copied the implementation of the `import` keyword, which functions very similarly.