### PR TITLE
[WIP] core: export evaluated config before whitelist

### DIFF
--- a/core/default.nix
+++ b/core/default.nix
@@ -90,7 +90,9 @@ let
         (whitelist "terraform") //
         (whitelist "variable");
 
-      _meta = meta;
+      _meta = meta // {
+        inherit evaluated;
+      };
     };
 
 in


### PR DESCRIPTION
Use-case: To add NixOS module style assertions and warnings in a downstream repo