### PR TITLE
chore: Update flake inputs and fix nixpkgs deprecations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4.1.1
-    - uses: cachix/install-nix-action@v23
+    - uses: cachix/install-nix-action@v31
       with:
-        nix_path: nixpkgs=channel:nixos-24.05
+        nix_path: nixpkgs=channel:nixos-25.05
     - name: Tests
       run: nix run ".#test"
     - name: Flake checks

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- chore: Update flake inputs and fix nixpkgs deprecations
 - fix: Use meta.mainProgram instead of hardcoded terraform binary (#156)
 - feat: add `.moved` and `.removed` keywords
 - chore: Add changelog check on CI (#141)

--- a/bin/terranix
+++ b/bin/terranix
@@ -69,6 +69,9 @@ then
     exit 1
 fi
 
+# Newer Nix leaks a "structuredAttrs is enabled" line from the build phase
+# of `pkgs.formats.json.generate` past --quiet. Filter just that line so
+# real errors (used by failure-case tests) still reach stderr.
 TERRAFORM_JSON=$( nix-build \
     --no-out-link \
     --attr run \
@@ -85,7 +88,7 @@ let
   };
 in
   { run = (pkgs.formats.json { }).generate \"config.tf.json\" terranixCore.config; }
-" )
+" 2> >(grep -v '^structuredAttrs is enabled$' >&2) )
 
 NIX_BUILD_EXIT_CODE=$?
 if [[ $NIX_BUILD_EXIT_CODE -eq 0 ]]

--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -16,7 +16,7 @@
             nixpkgs-fmt
             shfmt
             shellcheck
-            nodePackages.prettier
+            prettier
           ];
       };
 

--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -49,13 +49,11 @@
         doc = docs;
         docs.program = pkgs.writeShellApplication {
           name = "docs";
-          runtimeInputs = with pkgs; [ pandoc gnumake nix ];
+          runtimeInputs = with pkgs; [ pandoc gnumake ];
           text = ''
             make --always-make --directory=doc
-            nix build ".#manPages"
-            cp -r result/share .
+            cp -r ${config.packages.manPages}/share .
             chmod -R 755 ./share
-            rm result
           '';
         };
       };

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -13,7 +13,14 @@ let
     sha256 = "sha256-l2KsnY537mz0blZdqALZKrWXn9PD39CpvotgPnxyIP4=";
   };
 
-  nmd = import nmdSrc { inherit pkgs; };
+  # nmd uses the removed `pkgs.substituteAll`; shim it to `replaceVars`
+  # for compatibility with nixpkgs >= 2025-05-23.
+  nmdPkgs = pkgs // {
+    substituteAll = args:
+      pkgs.replaceVars args.src (removeAttrs args [ "src" ]);
+  };
+
+  nmd = import nmdSrc { pkgs = nmdPkgs; };
 
   # Make sure the used package is scrubbed to avoid actually
   # instantiating derivations.

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728956102,
-        "narHash": "sha256-J8zo+UYNjHATsxn2/ROl8iaji2RgLm+sG7b3VcD36YM=",
+        "lastModified": 1779959262,
+        "narHash": "sha256-/CKe+ffKTLngHU8SVvIjYUo3qzAiB8XNghYQEJkACAQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3d85bae2431f20ab1ac5cf14d03d314dffe629af",
+        "rev": "97ae3d51bc94cebb7171637c5a3b4aae8eb505b3",
         "type": "github"
       },
       "original": {

--- a/lib/terranix-doc-man.nix
+++ b/lib/terranix-doc-man.nix
@@ -14,7 +14,14 @@ let
     sha256 = "0rbx10n8kk0bvp1nl5c8q79lz1w0p1b8103asbvwps3gmqd070hi";
   };
 
-  nmd = import nmdSrc { inherit pkgs; };
+  # nmd uses the removed `pkgs.substituteAll`; shim it to `replaceVars`
+  # for compatibility with nixpkgs >= 2025-05-23.
+  nmdPkgs = pkgs // {
+    substituteAll = args:
+      pkgs.replaceVars args.src (removeAttrs args [ "src" ]);
+  };
+
+  nmd = import nmdSrc { pkgs = nmdPkgs; };
 
   # Make sure the used package is scrubbed to avoid actually
   # instantiating derivations.

--- a/share/man/man5/terranix-modules.5
+++ b/share/man/man5/terranix-modules.5
@@ -48,6 +48,9 @@ config\&.nix:
 \fIType:\fR
 lazy attribute set of raw value
 .sp
+\fIDefault:\fR
+{ }
+.sp
 \fIDeclared by:\fR
 .RS 4
 \m[blue]\fB<terranix/lib/modules\&.nix>\fR\m[]
@@ -242,7 +245,7 @@ bool, int, float or str
 .PP
 \fBimport\fR
 .RS 4
-\m[blue]\fB\fBimport\fR\fR\m[]Define terraform import\&. See for mote details : https://developer\&.hashicorp\&.com/terraform/language/import
+\m[blue]\fB\fBimport\fR\fR\m[]Define terraform import\&. See for more details : https://developer\&.hashicorp\&.com/terraform/language/import
 .sp
 \fIType:\fR
 bool, int, float or str
@@ -320,6 +323,36 @@ bool, int, float or str
       source = "github\&.com/hashicorp/example";
     };
   };
+}
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.PP
+\fBmoved\fR
+.RS 4
+\m[blue]\fB\fBmoved\fR\fR\m[]Move a resource from one address to another\&. See for more details : https://developer\&.hashicorp\&.com/terraform/language/block/moved
+.sp
+\fIType:\fR
+bool, int, float or str
+.sp
+\fIDefault:\fR
+{ }
+.sp
+\fIExample:\fR
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+{
+  moved = [
+    {
+      from = "aws_instance\&.example";
+      to = "aws_instance\&.other_example";
+    }
+  ];
 }
 .fi
 .if n \{\
@@ -558,6 +591,38 @@ string
 .RS 4
 \m[blue]\fB<terranix/modules/terraform/backends\&.nix>\fR\m[]
 .RE
+.RE
+.PP
+\fBremoved\fR
+.RS 4
+\m[blue]\fB\fBremoved\fR\fR\m[]Define a removed resource\&. See for more details : https://developer\&.hashicorp\&.com/terraform/language/state/remove
+.sp
+\fIType:\fR
+bool, int, float or str
+.sp
+\fIDefault:\fR
+{ }
+.sp
+\fIExample:\fR
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+{
+  removed = [
+    {
+      from = "aws_instance\&.example";
+      lifecycle = {
+        destroy = false;
+      };
+    }
+  ];
+}
+.fi
+.if n \{\
+.RE
+.\}
 .RE
 .PP
 \fBresource\fR


### PR DESCRIPTION
## chore: Update flake inputs and fix nixpkgs deprecations

- Bump nixpkgs and flake-parts
- Adapt to two removals in current nixpkgs:
  - `nodePackages.prettier` (now `pkgs.prettier`)
  - `pkgs.substituteAll` (replaced by `pkgs.replaceVars`).
- The latter is shimmed for the third-party `nmd` documentation generator, which still calls the removed API.

## fix(ci): Bump install-nix-action to v31 for Nix >= 2.18

The updated nixpkgs requires Nix >= 2.18, but install-nix-action@v23 installed Nix 2.17.0.

Bumping to v31 installs a current Nix and matching nixos-25.05 channel.

## fix(bin/terranix): Filter spurious "structuredAttrs is enabled" stderr line

Newer Nix leaks a "structuredAttrs is enabled" message from the build
 phase of `pkgs.formats.json.generate` past `--quiet`. The bats test harness captures stdout+stderr, so this extra line broke every
 output-comparing test under the updated nixpkgs.