### PR TITLE
feat(modules/terraform/backends): add encrypt and use_lockfile options to s3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- feat: add `encrypt`, `use_lockfile`, `skip_credentials_validation` and `skip_region_validation` options to s3 backend (#168)
+
 ## [2.9.0] 2026-05-28
 
 - chore: Update flake inputs and fix nixpkgs deprecations (#165)

--- a/modules/terraform/backends.nix
+++ b/modules/terraform/backends.nix
@@ -38,6 +38,34 @@ let
           region of the bucket
         '';
       };
+      encrypt = mkOption {
+        type = with types; nullOr bool;
+        default = null;
+        description = ''
+          enable server side encryption of the state file
+        '';
+      };
+      use_lockfile = mkOption {
+        type = with types; nullOr bool;
+        default = null;
+        description = ''
+          enable locking directly into the configured bucket for the state
+        '';
+      };
+      skip_credentials_validation = mkOption {
+        type = with types; nullOr bool;
+        default = null;
+        description = ''
+          skip credentials validation via the STS API
+        '';
+      };
+      skip_region_validation = mkOption {
+        type = with types; nullOr bool;
+        default = null;
+        description = ''
+          skip validation of provided region name
+        '';
+      };
     };
   };
 


### PR DESCRIPTION
and some more options necessary for non-AWS endpoints.