### PR TITLE
chore(default.nix): remove meta section from package derivation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- chore(default.nix): remove meta section from package derivation (#169)
 - chore(flake): split flake.nix into dendritic sub-modules (#170)
 - feat: add `encrypt`, `use_lockfile`, `skip_credentials_validation` and `skip_region_validation` options to s3 backend (#168)
 

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, jq, nix, makeWrapper }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "terranix";
   version = "2.9.0";
 
@@ -15,12 +15,4 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/terranix-doc-json \
       --prefix PATH : ${lib.makeBinPath [ jq nix ]}
   '';
-
-  meta = with lib; {
-    description = "A NixOS like terraform-json generator";
-    homepage = "https://terranix.org";
-    license = licenses.gpl3;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ mrVanDalo ];
-  };
 }


### PR DESCRIPTION
## Summary

- Drop the `meta` attrset from `default.nix` so packaging metadata (description, homepage, license, platforms, maintainers) lives with the packagers rather than being carried upstream.
- Remove the now-unused `rec` from `stdenv.mkDerivation`, since no attribute references a sibling anymore.