### PR TITLE
chore(flake): split flake.nix into dendritic sub-modules

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- chore(flake): split flake.nix into dendritic sub-modules (#170)
 - feat: add `encrypt`, `use_lockfile`, `skip_credentials_validation` and `skip_region_validation` options to s3 backend (#168)
 
 ## [2.9.0] 2026-05-28

--- a/dev/apps.nix
+++ b/dev/apps.nix
@@ -1,5 +1,4 @@
 { inputs, ... }:
-
 {
   perSystem =
     { config
@@ -7,19 +6,6 @@
     , ...
     }:
     {
-      devShells.default = pkgs.mkShell {
-        buildInputs = with pkgs;
-          [
-            terraform
-            config.packages.terranix
-            treefmt
-            nixpkgs-fmt
-            shfmt
-            shellcheck
-            prettier
-          ];
-      };
-
       apps = rec {
         test.program = pkgs.writeShellApplication {
           name = "test";
@@ -57,12 +43,5 @@
           '';
         };
       };
-
-      formatter = pkgs.treefmt;
     };
-
-  # nix flake init -t github:terranix/terranix#flake
-  flake.templates = inputs.terranix-examples.templates // {
-    default = inputs.terranix-examples.defaultTemplate;
-  };
 }

--- a/dev/checks.nix
+++ b/dev/checks.nix
@@ -1,3 +1,4 @@
+{ ... }:
 {
   perSystem =
     { pkgs
@@ -8,10 +9,11 @@
         let
           mockTerraformConfiguration = pkgs.writeText "config.tf.json" "{}";
 
-          mkMockTfPackage = name: pkgs.writeShellApplication {
-            inherit name;
-            text = ''echo "mock ${name} $*"'';
-          } // { meta.mainProgram = name; };
+          mkMockTfPackage = name: pkgs.writeShellApplication
+            {
+              inherit name;
+              text = ''echo "mock ${name} $*"'';
+            } // { meta.mainProgram = name; };
 
           mockTerraform = mkMockTfPackage "mock-terraform";
 

--- a/dev/devshell.nix
+++ b/dev/devshell.nix
@@ -1,0 +1,22 @@
+{ ... }:
+{
+  perSystem =
+    { config
+    , pkgs
+    , ...
+    }:
+    {
+      devShells.default = pkgs.mkShell {
+        buildInputs = with pkgs;
+          [
+            terraform
+            config.packages.terranix
+            treefmt
+            nixpkgs-fmt
+            shfmt
+            shellcheck
+            prettier
+          ];
+      };
+    };
+}

--- a/dev/formatter.nix
+++ b/dev/formatter.nix
@@ -1,0 +1,10 @@
+{ ... }:
+{
+  perSystem =
+    { pkgs
+    , ...
+    }:
+    {
+      formatter = pkgs.treefmt;
+    };
+}

--- a/dev/templates.nix
+++ b/dev/templates.nix
@@ -1,0 +1,7 @@
+{ inputs, ... }:
+{
+  # nix flake init -t github:terranix/terranix#flake
+  flake.templates = inputs.terranix-examples.templates // {
+    default = inputs.terranix-examples.defaultTemplate;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,21 @@
         "type": "github"
       }
     },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1784254960,
+        "narHash": "sha256-iI88R3wHz8wTKQb5orvpc51L/Xr64AJyxid/0MKa/b8=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "4ebb10ae17d5f1ad366e7aef5b92cb8eecf24f69",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1779959262,
@@ -38,6 +53,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "import-tree": "import-tree",
         "nixpkgs": "nixpkgs",
         "systems": "systems"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,197 +10,24 @@
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
+
+    import-tree.url = "github:vic/import-tree";
   };
 
-  outputs = inputs @ { self, flake-parts, nixpkgs, ... }:
-
-    flake-parts.lib.mkFlake { inherit inputs; } ({ flake-parts-lib, ... }: {
-      imports = [
-        (flake-parts-lib.importApply ./flake-module.nix { terranix = self; })
-        flake-parts.flakeModules.partitions
-      ];
-
-      systems = import
-        inputs.systems;
-
-      partitions.dev = {
-        extraInputsFlake = ./dev;
-        module.imports = [
-          ./dev/flake-module.nix
-          ./dev/flake-module-checks.nix
+  outputs = inputs @ { flake-parts, import-tree, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } ({ self, flake-parts-lib, ... }:
+      let
+        # Kept out of the import-tree'd ./flake: it's a `{ terranix }:` function,
+        # not a plain module, so it needs importApply to bind terranix and keep
+        # its _file. https://flake.parts/define-module-in-separate-file.html
+        flakeModule = flake-parts-lib.importApply ./flake-module.nix { terranix = self; };
+      in
+      {
+        imports = [
+          (import-tree ./flake)
+          flakeModule
         ];
-      };
 
-      partitionedAttrs = {
-        apps = "dev";
-        checks = "dev";
-        devShells = "dev";
-        formatter = "dev";
-        templates = "dev";
-      };
-
-      perSystem =
-        { pkgs
-        , system
-        , ...
-        }:
-        {
-          _module.args.pkgs = import inputs.nixpkgs {
-            inherit system;
-            config = {
-              allowUnfree = true;
-            };
-          };
-          packages = rec {
-            default = terranix;
-
-            terranix = pkgs.callPackage ./default.nix {
-              nix = pkgs.nixVersions.git;
-            };
-
-            inherit (pkgs.callPackage ./doc/default.nix { }) manPages;
-          };
-        };
-
-      flake = {
-
-        flakeModule = (flake-parts-lib.importApply ./flake-module.nix { terranix = self; });
-
-        # terraformConfiguration ast, if you want to run
-        # terranix in the repl.
-        lib.terranixConfigurationAst = args:
-          nixpkgs.lib.warn "terranixConfigurationAst will be removed in 3.0.0 use terranixConfiguration.config instead"
-            (self.lib.terranixConfiguration args);
-
-        # terranixOptions ast, if you want to run
-        # terranix in a repl.
-        lib.terranixOptionsAst =
-          { system ? ""
-          , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
-          , modules ? [ ]
-          , moduleRootPath ? "/"
-          , urlPrefix ? ""
-          , urlSuffix ? ""
-          }:
-          import ./lib/terranix-doc-json.nix {
-            terranix_modules = modules;
-            inherit moduleRootPath urlPrefix urlSuffix pkgs;
-          };
-
-        # Evaluate terranix modules
-        # Returns { config = <terraform attrset>; _meta = <attrset>; }
-        lib.evalTerranixConfiguration =
-          { system ? ""
-          , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
-          , extraArgs ? { }
-          , modules ? [ ]
-          , strip_nulls ? true
-          }:
-          import ./core/default.nix {
-            inherit pkgs strip_nulls modules extraArgs;
-          };
-
-        # create a config.tf.json derivation
-        # you have to either have to name a system or set pkgs.
-        lib.terranixConfiguration =
-          { system ? ""
-          , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
-          , extraArgs ? { }
-          , modules ? [ ]
-          , strip_nulls ? true
-          }:
-          let
-            terranixCore = self.lib.evalTerranixConfiguration {
-              inherit pkgs strip_nulls modules extraArgs;
-            };
-            terraformConfig = (pkgs.formats.json { }).generate "config.tf.json" terranixCore.config;
-          in
-          terraformConfig.overrideAttrs {
-            passthru = terranixCore;
-          };
-
-        lib.mkTerranixOutputs = import ./core/terraform-invocs.nix;
-
-        # create a options.json.
-        # you have to either have to name a system or set pkgs.
-        lib.terranixOptions =
-          { system ? ""
-          , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
-          , modules ? [ ]
-          , moduleRootPath ? "/"
-          , urlPrefix ? ""
-          , urlSuffix ? ""
-          }:
-          let
-            terranixOptions = import ./lib/terranix-doc-json.nix {
-              terranix_modules = modules;
-              inherit moduleRootPath urlPrefix urlSuffix pkgs;
-            };
-          in
-          pkgs.runCommand "terranix-options" { }
-            ''
-              cat ${terranixOptions}/options.json | \
-                ${pkgs.jq}/bin/jq '
-                  del(.ephemeral) |
-                  del(.data) |
-                  del(.import) |
-                  del(.locals) |
-                  del(.module) |
-                  del(.moved) |
-                  del(.output) |
-                  del(.provider) |
-                  del(.removed) |
-                  del(.resource) |
-                  del(.terraform) |
-                  del(.variable)
-                  ' > $out
-            '';
-
-        # deprecated
-        lib.buildTerranix = nixpkgs.lib.warn "buildTerranix will be removed in 3.0.0 use terranixConfiguration instead"
-          ({ pkgs, ... }@terranix_args:
-            let terranixCore = import ./core/default.nix terranix_args;
-            in
-            pkgs.writeTextFile {
-              name = "config.tf.json";
-              text = builtins.toJSON terranixCore.config;
-            });
-
-        # deprecated
-        lib.buildOptions =
-          nixpkgs.lib.warn "buildOptions will be removed in 3.0.0 use terranixOptions instead"
-            ({ pkgs
-             , terranix_modules
-             , moduleRootPath ? "/"
-             , urlPrefix ? ""
-             , urlSuffix ? ""
-             , ...
-             }@terranix_args:
-              let
-                terranixOptions = import ./lib/terranix-doc-json.nix terranix_args;
-              in
-              pkgs.stdenv.mkDerivation {
-                name = "terranix-options";
-                src = self;
-                installPhase = ''
-                  mkdir -p $out
-                  cat ${terranixOptions}/options.json \
-                    | ${pkgs.jq}/bin/jq '
-                      del(.ephemeral) |
-                      del(.data) |
-                      del(.import) |
-                      del(.locals) |
-                      del(.module) |
-                      del(.moved) |
-                      del(.output) |
-                      del(.provider) |
-                      del(.resource) |
-                      del(.removed) |
-                      del(.terraform) |
-                      del(.variable)
-                      ' > $out/options.json
-                '';
-              });
-      };
-    });
+        flake.flakeModule = flakeModule;
+      });
 }

--- a/flake/lib.nix
+++ b/flake/lib.nix
@@ -1,0 +1,143 @@
+{ self, inputs, ... }:
+let
+  inherit (inputs) nixpkgs;
+in
+{
+  flake = {
+    # terraformConfiguration ast, if you want to run
+    # terranix in the repl.
+    lib.terranixConfigurationAst = args:
+      nixpkgs.lib.warn "terranixConfigurationAst will be removed in 3.0.0 use terranixConfiguration.config instead"
+        (self.lib.terranixConfiguration args);
+
+    # terranixOptions ast, if you want to run
+    # terranix in a repl.
+    lib.terranixOptionsAst =
+      { system ? ""
+      , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
+      , modules ? [ ]
+      , moduleRootPath ? "/"
+      , urlPrefix ? ""
+      , urlSuffix ? ""
+      }:
+      import ../lib/terranix-doc-json.nix {
+        terranix_modules = modules;
+        inherit moduleRootPath urlPrefix urlSuffix pkgs;
+      };
+
+    # Evaluate terranix modules
+    # Returns { config = <terraform attrset>; _meta = <attrset>; }
+    lib.evalTerranixConfiguration =
+      { system ? ""
+      , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
+      , extraArgs ? { }
+      , modules ? [ ]
+      , strip_nulls ? true
+      }:
+      import ../core/default.nix {
+        inherit pkgs strip_nulls modules extraArgs;
+      };
+
+    # create a config.tf.json derivation
+    # you have to either have to name a system or set pkgs.
+    lib.terranixConfiguration =
+      { system ? ""
+      , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
+      , extraArgs ? { }
+      , modules ? [ ]
+      , strip_nulls ? true
+      }:
+      let
+        terranixCore = self.lib.evalTerranixConfiguration {
+          inherit pkgs strip_nulls modules extraArgs;
+        };
+        terraformConfig = (pkgs.formats.json { }).generate "config.tf.json" terranixCore.config;
+      in
+      terraformConfig.overrideAttrs {
+        passthru = terranixCore;
+      };
+
+    lib.mkTerranixOutputs = import ../core/terraform-invocs.nix;
+
+    # create a options.json.
+    # you have to either have to name a system or set pkgs.
+    lib.terranixOptions =
+      { system ? ""
+      , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
+      , modules ? [ ]
+      , moduleRootPath ? "/"
+      , urlPrefix ? ""
+      , urlSuffix ? ""
+      }:
+      let
+        terranixOptions = import ../lib/terranix-doc-json.nix {
+          terranix_modules = modules;
+          inherit moduleRootPath urlPrefix urlSuffix pkgs;
+        };
+      in
+      pkgs.runCommand "terranix-options" { }
+        ''
+          cat ${terranixOptions}/options.json | \
+            ${pkgs.jq}/bin/jq '
+              del(.ephemeral) |
+              del(.data) |
+              del(.import) |
+              del(.locals) |
+              del(.module) |
+              del(.moved) |
+              del(.output) |
+              del(.provider) |
+              del(.removed) |
+              del(.resource) |
+              del(.terraform) |
+              del(.variable)
+              ' > $out
+        '';
+
+    # deprecated
+    lib.buildTerranix = nixpkgs.lib.warn "buildTerranix will be removed in 3.0.0 use terranixConfiguration instead"
+      ({ pkgs, ... }@terranix_args:
+        let terranixCore = import ../core/default.nix terranix_args;
+        in
+        pkgs.writeTextFile {
+          name = "config.tf.json";
+          text = builtins.toJSON terranixCore.config;
+        });
+
+    # deprecated
+    lib.buildOptions =
+      nixpkgs.lib.warn "buildOptions will be removed in 3.0.0 use terranixOptions instead"
+        ({ pkgs
+         , terranix_modules
+         , moduleRootPath ? "/"
+         , urlPrefix ? ""
+         , urlSuffix ? ""
+         , ...
+         }@terranix_args:
+          let
+            terranixOptions = import ../lib/terranix-doc-json.nix terranix_args;
+          in
+          pkgs.stdenv.mkDerivation {
+            name = "terranix-options";
+            src = self;
+            installPhase = ''
+              mkdir -p $out
+              cat ${terranixOptions}/options.json \
+                | ${pkgs.jq}/bin/jq '
+                  del(.ephemeral) |
+                  del(.data) |
+                  del(.import) |
+                  del(.locals) |
+                  del(.module) |
+                  del(.moved) |
+                  del(.output) |
+                  del(.provider) |
+                  del(.resource) |
+                  del(.removed) |
+                  del(.terraform) |
+                  del(.variable)
+                  ' > $out/options.json
+            '';
+          });
+  };
+}

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -1,0 +1,25 @@
+{ inputs, ... }:
+{
+  perSystem =
+    { pkgs
+    , system
+    , ...
+    }:
+    {
+      _module.args.pkgs = import inputs.nixpkgs {
+        inherit system;
+        config = {
+          allowUnfree = true;
+        };
+      };
+      packages = rec {
+        default = terranix;
+
+        terranix = pkgs.callPackage ../default.nix {
+          nix = pkgs.nixVersions.git;
+        };
+
+        inherit (pkgs.callPackage ../doc/default.nix { }) manPages;
+      };
+    };
+}

--- a/flake/partitions.nix
+++ b/flake/partitions.nix
@@ -1,0 +1,20 @@
+{ inputs, ... }:
+{
+  imports = [ inputs.flake-parts.flakeModules.partitions ];
+
+  # The dev-only inputs and modules live in a second dendritic tree in /dev.
+  partitions.dev = {
+    extraInputsFlake = ../dev;
+    module.imports = [
+      ((inputs.import-tree.filterNot (p: builtins.baseNameOf p == "flake.nix")) ../dev)
+    ];
+  };
+
+  partitionedAttrs = {
+    apps = "dev";
+    checks = "dev";
+    devShells = "dev";
+    formatter = "dev";
+    templates = "dev";
+  };
+}

--- a/flake/systems.nix
+++ b/flake/systems.nix
@@ -1,0 +1,4 @@
+{ inputs, ... }:
+{
+  systems = import inputs.systems;
+}


### PR DESCRIPTION
flake.nix:
- Adds import-tree.
- Reduces to inputs plus `mkFlake { inherit inputs; } (import-tree ./flake)`.
- Moves `flake-parts.flakeModules.partitions` import into flake/partitions.nix.

flake-module.nix:
- Stays in its own file at repo root because of https://flake.parts website doc generator support:
  While it's not necessary to stay at the repo root, it's necessary that the flakeModule is not
  embedded but lives as the top-level expression. However, all flake/*.nix are flake-parts modules.

flake/:
- Splits into systems.nix, packages.nix, lib.nix, partitions.nix.
- Carry the former per-aspect outputs (only paths changed).

dev/:
- Stays in repo-root as a second dendritic subtree, import-tree'd by the dev partition.
- Is also the dev partition's input flake (dev/flake.{nix,lock}).
- flake.nix is filtered out of the imported tree because it's not a flake-parts module.
- Split the former dev/flake-module{,-checks}.nix into dev/{devshell,apps,formatter,templates,checks}.nix.

Verified:
- Root flake.lock stays at four nodes (flake-parts, import-tree, nixpkgs, systems)
- `nix build .#terranix` needs no dev inputs.
- `nix flake check`/`show` and the partitioned outputs all resolve.