### PR TITLE
feat(core): add NixOS-style assertions and warnings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,9 @@
 ## [Unreleased]
 
 - feat(core): add NixOS-style `assertions` and `warnings` options
-- refactor(modules/terraform/backends): report every failed assertion at once; failure output changes from `Failed assertion: <msg>` to a `Failed assertions:` header followed by one `- <msg>` line per failure
+- refactor(modules/terraform/backends): use `assertions` instead of `mkAssert`, so every failed assertion is reported at once
+- change: assertion failures now print a `Failed assertions:` header with one `- <msg>` line per failure, replacing `Failed assertion: <msg>`
+- change: modules declaring their own top-level `assertions` or `warnings` option now conflict with the built-in ones and must be renamed
 - chore(default.nix): remove meta section from package derivation (#169)
 - chore(flake): split flake.nix into dendritic sub-modules (#170)
 - feat: add `encrypt`, `use_lockfile`, `skip_credentials_validation` and `skip_region_validation` options to s3 backend (#168)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- feat(core): add NixOS-style `assertions` and `warnings` options
+- refactor(modules/terraform/backends): report every failed assertion at once; failure output changes from `Failed assertion: <msg>` to a `Failed assertions:` header followed by one `- <msg>` line per failure
 - chore(default.nix): remove meta section from package derivation (#169)
 - chore(flake): split flake.nix into dendritic sub-modules (#170)
 - feat: add `encrypt`, `use_lockfile`, `skip_credentials_validation` and `skip_region_validation` options to s3 backend (#168)

--- a/core/default.nix
+++ b/core/default.nix
@@ -62,8 +62,9 @@ let
   terranix = mods:
     let
       evaluated = evaluateConfiguration mods;
+      inherit (evaluated.config) assertions warnings;
       meta = evaluated.config._meta or { };
-      result = sanitize (removeAttrs evaluated.config [ "_meta" ]);
+      result = sanitize (removeAttrs evaluated.config [ "_meta" "assertions" "warnings" ]);
       genericWhitelist = f: key:
         let attr = f result.${key};
         in
@@ -76,7 +77,7 @@ let
       whitelistWithoutEmpty = genericWhitelist (filterAttrs (name: attr: attr != { }));
     in
     {
-      config = { } //
+      config = lib'.asserts.checkAssertWarn assertions warnings ({ } //
         (whitelistWithoutEmpty "ephemeral") //
         (whitelistWithoutEmpty "data") //
         (whitelist "import") //
@@ -88,8 +89,9 @@ let
         (whitelist "removed") //
         (whitelistWithoutEmpty "resource") //
         (whitelist "terraform") //
-        (whitelist "variable");
+        (whitelist "variable"));
 
+      inherit assertions warnings;
       _meta = meta;
     };
 

--- a/core/terraform-options.nix
+++ b/core/terraform-options.nix
@@ -7,12 +7,11 @@ with lib;
 
 let
   mkMagicMergeOption =
-    {
-      description ? "",
-      example ? { },
-      default ? { },
-      apply ? id,
-      ...
+    { description ? ""
+    , example ? { }
+    , default ? { }
+    , apply ? id
+    , ...
     }:
     mkOption {
       inherit
@@ -25,14 +24,15 @@ let
         with lib.types;
         let
           valueType =
-            nullOr (oneOf [
-              bool
-              int
-              float
-              str
-              (attrsOf valueType)
-              (listOf valueType)
-            ])
+            nullOr
+              (oneOf [
+                bool
+                int
+                float
+                str
+                (attrsOf valueType)
+                (listOf valueType)
+              ])
             // {
               description = "bool, int, float or str";
               emptyValue.value = { };
@@ -42,9 +42,8 @@ let
     };
 
   mkReferenceableOption =
-    {
-      referencePrefix ? "",
-      ...
+    { referencePrefix ? ""
+    , ...
     }@args:
     mkMagicMergeOption (
       args
@@ -55,13 +54,15 @@ let
           in
           mapAttrsOrSkip (
             type: v1:
-            mapAttrsOrSkip (
-              label: v2:
-              if isAttrs v2 then
-                v2 // { __functor = self: attr: "\${${referencePrefix}${type}.${label}.${attr}}"; }
-              else
-                v2
-            ) v1
+              mapAttrsOrSkip
+                (
+                  label: v2:
+                    if isAttrs v2 then
+                      v2 // { __functor = self: attr: "\${${referencePrefix}${type}.${label}.${attr}}"; }
+                    else
+                      v2
+                )
+                v1
           );
       }
     );

--- a/core/terraform-options.nix
+++ b/core/terraform-options.nix
@@ -80,6 +80,34 @@ in
       description = "Arbitrary metadata attached to a terranix evaluation result.";
     };
 
+    # Checked in core/default.nix once the configuration is assembled.
+    # Neither option is rendered to Terraform JSON.
+    assertions = mkOption {
+      type = types.listOf types.unspecified;
+      default = [ ];
+      internal = true;
+      example = [{
+        assertion = false;
+        message = "you can't enable this for that reason";
+      }];
+      description = ''
+        Conditions that must hold for the evaluation of the terranix
+        configuration to succeed, together with the message shown to the
+        user when they do not.
+      '';
+    };
+
+    warnings = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      internal = true;
+      example = [ "The etcd backend is deprecated and will go away soon!" ];
+      description = ''
+        Messages to show to users during the evaluation of the terranix
+        configuration, without failing it.
+      '';
+    };
+
     ephemeral = mkReferenceableOption {
       referencePrefix = "ephemeral.";
       description = ''

--- a/dev/checks.nix
+++ b/dev/checks.nix
@@ -79,6 +79,33 @@
               "terraform init"
               "terraform apply"
             ];
+
+          # a failed assertion must not block reading assertions/warnings/_meta,
+          # only config; mirrors nixos, where unrelated config stays readable
+          failed-assertion-keeps-result-readable =
+            let
+              result = import ../core/default.nix {
+                inherit pkgs;
+                modules = [{
+                  assertions = [{
+                    assertion = false;
+                    message = "deliberately failing assertion";
+                  }];
+                  warnings = [ "deliberately reachable warning" ];
+                  _meta.marker = "deliberately reachable meta";
+                }];
+              };
+              ok =
+                builtins.elem
+                  { assertion = false; message = "deliberately failing assertion"; }
+                  result.assertions
+                && builtins.elem "deliberately reachable warning" result.warnings
+                && result._meta.marker == "deliberately reachable meta";
+            in
+            assert ok;
+            pkgs.runCommand "failed-assertion-keeps-result-readable" { } ''
+              echo "PASS" > $out
+            '';
         };
     };
 }

--- a/doc/man-terranix_conditions.refsection.md
+++ b/doc/man-terranix_conditions.refsection.md
@@ -3,6 +3,9 @@
 Conditions and assertions can be used to throw human readable exceptions and
 to create conditional terraform resources or parameters.
 
+`assertions` and `warnings` are internal options and do not appear in the
+generated options reference; this section is their documentation.
+
 ## assertions
 
 Add an entry to the `assertions` option to state a condition that has to hold
@@ -36,6 +39,8 @@ error:
 
 `warnings` is the non-fatal counterpart. Every string in the list is printed
 while the configuration is evaluated, and the terraform JSON is still written.
+A failing assertion aborts before warnings are shown, so pending warnings do
+not print alongside it.
 
 ```nix
 config = {

--- a/doc/man-terranix_conditions.refsection.md
+++ b/doc/man-terranix_conditions.refsection.md
@@ -3,10 +3,52 @@
 Conditions and assertions can be used to throw human readable exceptions and
 to create conditional terraform resources or parameters.
 
+## assertions
+
+Add an entry to the `assertions` option to state a condition that has to hold
+for the configuration to be valid. Every failing assertion is collected, so one
+run tells you about every problem at once.
+
+```nix
+config = {
+  assertions = [
+    {
+      assertion = cfg.parameter != "fail";
+      message = "parameter is set to fail!";
+    }
+  ];
+
+  resource.aws_what_ever."${cfg.parameter}" = {
+    I = "love nixos";
+  };
+};
+```
+
+A failing assertion aborts terranix before any terraform JSON is written.
+
+```
+error:
+       Failed assertions:
+       - parameter is set to fail!
+```
+
+## warnings
+
+`warnings` is the non-fatal counterpart. Every string in the list is printed
+while the configuration is evaluated, and the terraform JSON is still written.
+
+```nix
+config = {
+  warnings = optional (config.backend.etcd != null)
+    "the etcd backend is deprecated, migrate to s3";
+};
+```
+
 ## mkAssert
 
-To make an assertion in your module use the `mkAssert` command.
-Here is an example
+`mkAssert` guards a single value rather than the whole configuration, and
+throws on the first failure it reaches. Prefer `assertions`, and reach for
+`mkAssert` only to protect a value that must not be evaluated at all.
 
 ```nix
 config = mkAssert (cfg.parameter != "fail") "parameter is set to fail!" {

--- a/doc/man-terranix_conditions.refsection.xml
+++ b/doc/man-terranix_conditions.refsection.xml
@@ -5,6 +5,11 @@
     exceptions and to create conditional terraform resources or
     parameters.
   </para>
+  <para>
+    <literal>assertions</literal> and <literal>warnings</literal> are
+    internal options and do not appear in the generated options
+    reference; this section is their documentation.
+  </para>
   <refsection xml:id="assertions">
     <title>assertions</title>
     <para>
@@ -42,7 +47,9 @@ error:
     <para>
       <literal>warnings</literal> is the non-fatal counterpart. Every
       string in the list is printed while the configuration is
-      evaluated, and the terraform JSON is still written.
+      evaluated, and the terraform JSON is still written. A failing
+      assertion aborts before warnings are shown, so pending warnings do
+      not print alongside it.
     </para>
     <programlisting language="nix">
 config = {

--- a/doc/man-terranix_conditions.refsection.xml
+++ b/doc/man-terranix_conditions.refsection.xml
@@ -5,11 +5,60 @@
     exceptions and to create conditional terraform resources or
     parameters.
   </para>
+  <refsection xml:id="assertions">
+    <title>assertions</title>
+    <para>
+      Add an entry to the <literal>assertions</literal> option to state
+      a condition that has to hold for the configuration to be valid.
+      Every failing assertion is collected, so one run tells you about
+      every problem at once.
+    </para>
+    <programlisting language="nix">
+config = {
+  assertions = [
+    {
+      assertion = cfg.parameter != &quot;fail&quot;;
+      message = &quot;parameter is set to fail!&quot;;
+    }
+  ];
+
+  resource.aws_what_ever.&quot;${cfg.parameter}&quot; = {
+    I = &quot;love nixos&quot;;
+  };
+};
+</programlisting>
+    <para>
+      A failing assertion aborts terranix before any terraform JSON is
+      written.
+    </para>
+    <programlisting>
+error:
+       Failed assertions:
+       - parameter is set to fail!
+</programlisting>
+  </refsection>
+  <refsection xml:id="warnings">
+    <title>warnings</title>
+    <para>
+      <literal>warnings</literal> is the non-fatal counterpart. Every
+      string in the list is printed while the configuration is
+      evaluated, and the terraform JSON is still written.
+    </para>
+    <programlisting language="nix">
+config = {
+  warnings = optional (config.backend.etcd != null)
+    &quot;the etcd backend is deprecated, migrate to s3&quot;;
+};
+</programlisting>
+  </refsection>
   <refsection xml:id="mkassert">
     <title>mkAssert</title>
     <para>
-      To make an assertion in your module use the
-      <literal>mkAssert</literal> command. Here is an example
+      <literal>mkAssert</literal> guards a single value rather than the
+      whole configuration, and throws on the first failure it reaches.
+      Prefer <literal>assertions</literal>, and reach for
+      <literal>mkAssert</literal> only to protect a value that must not
+      be evaluated at all.
     </para>
     <programlisting language="nix">
 config = mkAssert (cfg.parameter != &quot;fail&quot;) &quot;parameter is set to fail!&quot; {

--- a/modules/terraform/backends.nix
+++ b/modules/terraform/backends.nix
@@ -163,26 +163,25 @@ in
       backends = [ "local" "s3" "etcd" ];
       notNull = element: !(isNull element);
 
+      definedBackends = filter notNull
+        (map (backend: config.backend."${backend}") backends);
+
+      allRemoteStates = flatten
+        (map attrNames
+          (filter (element: element != { })
+            (map (backend: config.remote_state."${backend}") backends)));
+
       backendConfigurations =
         let
           rule = backend:
             mkIf (config.backend."${backend}" != null) {
               terraform."backend"."${backend}" = config.backend."${backend}";
             };
-
-          backendConfigs = map (backend: config.backend."${backend}") backends;
         in
-        mkAssert (length (filter notNull backendConfigs) < 2)
-          "You defined multiple backends, stick to one!"
-          (mkMerge (map rule backends));
+        mkMerge (map rule backends);
 
       remoteConfigurations =
         let
-          backendConfigs = map (backend: config.remote_state."${backend}") backends;
-          allRemoteStates = flatten
-            (map attrNames (filter (element: element != { }) backendConfigs));
-          uniqueRemoteStates = unique allRemoteStates;
-
           remote = backend:
             mkIf (config.remote_state."${backend}" != { }) {
               data."terraform_remote_state" = mapAttrs
@@ -193,10 +192,23 @@ in
                 config.remote_state."${backend}";
             };
         in
-        mkAssert (length allRemoteStates == length uniqueRemoteStates)
-          "You defined multiple terraform_states with the same name!"
-          (mkMerge (map remote backends));
+        mkMerge (map remote backends);
     in
-    mkMerge [ backendConfigurations remoteConfigurations ];
+    mkMerge [
+      backendConfigurations
+      remoteConfigurations
+      {
+        assertions = [
+          {
+            assertion = length definedBackends < 2;
+            message = "You defined multiple backends, stick to one!";
+          }
+          {
+            assertion = allRemoteStates == unique allRemoteStates;
+            message = "You defined multiple terraform_states with the same name!";
+          }
+        ];
+      }
+    ];
 
 }

--- a/share/man/man1/terranix.1
+++ b/share/man/man1/terranix.1
@@ -418,6 +418,11 @@ Now you can set the following
 .SH "CONDITIONS AND ASSERTIONS"
 .PP
 Conditions and assertions can be used to throw human readable exceptions and to create conditional terraform resources or parameters\&.
+.PP
+assertions
+and
+warnings
+are internal options and do not appear in the generated options reference; this section is their documentation\&.
 .SS "assertions"
 .PP
 Add an entry to the
@@ -461,7 +466,7 @@ error:
 .SS "warnings"
 .PP
 warnings
-is the non\-fatal counterpart\&. Every string in the list is printed while the configuration is evaluated, and the terraform JSON is still written\&.
+is the non\-fatal counterpart\&. Every string in the list is printed while the configuration is evaluated, and the terraform JSON is still written\&. A failing assertion aborts before warnings are shown, so pending warnings do not print alongside it\&.
 .sp
 .if n \{\
 .RS 4

--- a/share/man/man1/terranix.1
+++ b/share/man/man1/terranix.1
@@ -418,11 +418,70 @@ Now you can set the following
 .SH "CONDITIONS AND ASSERTIONS"
 .PP
 Conditions and assertions can be used to throw human readable exceptions and to create conditional terraform resources or parameters\&.
+.SS "assertions"
+.PP
+Add an entry to the
+assertions
+option to state a condition that has to hold for the configuration to be valid\&. Every failing assertion is collected, so one run tells you about every problem at once\&.
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+config = {
+  assertions = [
+    {
+      assertion = cfg\&.parameter != "fail";
+      message = "parameter is set to fail!";
+    }
+  ];
+
+  resource\&.aws_what_ever\&."${cfg\&.parameter}" = {
+    I = "love nixos";
+  };
+};
+.fi
+.if n \{\
+.RE
+.\}
+.PP
+A failing assertion aborts terranix before any terraform JSON is written\&.
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+error:
+       Failed assertions:
+       \- parameter is set to fail!
+.fi
+.if n \{\
+.RE
+.\}
+.SS "warnings"
+.PP
+warnings
+is the non\-fatal counterpart\&. Every string in the list is printed while the configuration is evaluated, and the terraform JSON is still written\&.
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+config = {
+  warnings = optional (config\&.backend\&.etcd != null)
+    "the etcd backend is deprecated, migrate to s3";
+};
+.fi
+.if n \{\
+.RE
+.\}
 .SS "mkAssert"
 .PP
-To make an assertion in your module use the
 mkAssert
-command\&. Here is an example
+guards a single value rather than the whole configuration, and throws on the first failure it reaches\&. Prefer
+assertions, and reach for
+mkAssert
+only to protect a value that must not be evaluated at all\&.
 .sp
 .if n \{\
 .RS 4

--- a/tests/terranix-tests.nix
+++ b/tests/terranix-tests.nix
@@ -115,5 +115,6 @@
     file = ./terranix-tests/19-warnings.nix;
     outputFile = ./terranix-tests/19-warnings-json.nix.output;
     partialMatchOutput = true;
+    refuteOutput = "\"warnings\"";
   }
 ]

--- a/tests/terranix-tests.nix
+++ b/tests/terranix-tests.nix
@@ -91,4 +91,29 @@
     file = ./terranix-tests/16.nix;
     outputFile = ./terranix-tests/16.nix.output;
   }
+  {
+    text = "assertions : a satisfied assertion is silent and stays out of the json";
+    file = ./terranix-tests/17-assertions.nix;
+    outputFile = ./terranix-tests/17-assertions.nix.output;
+  }
+  {
+    text = "assertions : every failing assertion is reported together";
+    file = ./terranix-tests/18-assertions-fail.nix;
+    success = false;
+    outputFile = ./terranix-tests/18-assertions-fail.nix.output;
+    partialMatchOutput = true;
+    dedentOutput = true;
+  }
+  {
+    text = "warnings : a warning is printed to the user";
+    file = ./terranix-tests/19-warnings.nix;
+    outputFile = ./terranix-tests/19-warnings-message.nix.output;
+    partialMatchOutput = true;
+  }
+  {
+    text = "warnings : a warning does not fail the build or reach the json";
+    file = ./terranix-tests/19-warnings.nix;
+    outputFile = ./terranix-tests/19-warnings-json.nix.output;
+    partialMatchOutput = true;
+  }
 ]

--- a/tests/terranix-tests/02.nix.output
+++ b/tests/terranix-tests/02.nix.output
@@ -1,1 +1,1 @@
-Failed assertion: You defined multiple backends, stick to one!
+- You defined multiple backends, stick to one!

--- a/tests/terranix-tests/03.nix.output
+++ b/tests/terranix-tests/03.nix.output
@@ -1,1 +1,1 @@
-Failed assertion: You defined multiple terraform_states with the same name!
+- You defined multiple terraform_states with the same name!

--- a/tests/terranix-tests/17-assertions.nix
+++ b/tests/terranix-tests/17-assertions.nix
@@ -1,0 +1,11 @@
+{ ... }:
+{
+  assertions = [
+    {
+      assertion = true;
+      message = "this assertion never fires";
+    }
+  ];
+
+  locals.yolo = "value";
+}

--- a/tests/terranix-tests/17-assertions.nix.output
+++ b/tests/terranix-tests/17-assertions.nix.output
@@ -1,0 +1,5 @@
+{
+  "locals": {
+    "yolo": "value"
+  }
+}

--- a/tests/terranix-tests/18-assertions-fail.nix
+++ b/tests/terranix-tests/18-assertions-fail.nix
@@ -1,0 +1,17 @@
+{ ... }:
+{
+  assertions = [
+    {
+      assertion = false;
+      message = "first problem";
+    }
+    {
+      assertion = true;
+      message = "not a problem";
+    }
+    {
+      assertion = false;
+      message = "second problem";
+    }
+  ];
+}

--- a/tests/terranix-tests/18-assertions-fail.nix.output
+++ b/tests/terranix-tests/18-assertions-fail.nix.output
@@ -1,0 +1,3 @@
+Failed assertions:
+- first problem
+- second problem

--- a/tests/terranix-tests/19-warnings-json.nix.output
+++ b/tests/terranix-tests/19-warnings-json.nix.output
@@ -1,0 +1,5 @@
+{
+  "locals": {
+    "yolo": "value"
+  }
+}

--- a/tests/terranix-tests/19-warnings-message.nix.output
+++ b/tests/terranix-tests/19-warnings-message.nix.output
@@ -1,0 +1,1 @@
+the etcd backend is deprecated, migrate to s3

--- a/tests/terranix-tests/19-warnings.nix
+++ b/tests/terranix-tests/19-warnings.nix
@@ -1,0 +1,6 @@
+{ ... }:
+{
+  warnings = [ "the etcd backend is deprecated, migrate to s3" ];
+
+  locals.yolo = "value";
+}

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -7,9 +7,10 @@ let
   #  file = ./terranix-tests/05.nix;
   #  success = true;
   #  outputFile = ./terranix-tests/05.nix.output;
+  #  dedentOutput = true;
   #} ]
   terranix-tests = import ./terranix-tests.nix;
-  terranix-test-template = { text, file, options ? [ ], success ? true, outputFile ? "", partialMatchOutput ? false, ... }:
+  terranix-test-template = { text, file, options ? [ ], success ? true, outputFile ? "", partialMatchOutput ? false, dedentOutput ? false, ... }:
     ''
       @test "${text}" {
       run ${terranix}/bin/terranix ${concatStringsSep " " options} --pkgs ${nixpkgs} --quiet ${file}
@@ -17,7 +18,10 @@ let
       # edit output to make sure no nix store paths are included
       # - they cause tests to fail depending on environment
       output=$(echo "$output" | sed 's|/nix/store/.*-|<nix store path>-|')
-
+      ${optionalString dedentOutput ''
+        # nix indents every continuation line of a multi-line error by 7 spaces
+        output=$(echo "$output" | sed 's|^       ||')
+      ''}
       ${if success then "assert_success" else "assert_failure"}
       ${optionalString (outputFile != "") "assert_output ${optionalString partialMatchOutput "--partial"} ${escapeShellArg (fileContents outputFile)}"}
       }

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -7,10 +7,12 @@ let
   #  file = ./terranix-tests/05.nix;
   #  success = true;
   #  outputFile = ./terranix-tests/05.nix.output;
-  #  dedentOutput = true;
   #} ]
+  # dedentOutput strips nix's indentation from multi-line error text; only
+  # pair it with a failure whose outputFile is written unindented, never
+  # with an exact-match success case like the one above.
   terranix-tests = import ./terranix-tests.nix;
-  terranix-test-template = { text, file, options ? [ ], success ? true, outputFile ? "", partialMatchOutput ? false, dedentOutput ? false, ... }:
+  terranix-test-template = { text, file, options ? [ ], success ? true, outputFile ? "", partialMatchOutput ? false, dedentOutput ? false, refuteOutput ? "", ... }:
     ''
       @test "${text}" {
       run ${terranix}/bin/terranix ${concatStringsSep " " options} --pkgs ${nixpkgs} --quiet ${file}
@@ -19,11 +21,13 @@ let
       # - they cause tests to fail depending on environment
       output=$(echo "$output" | sed 's|/nix/store/.*-|<nix store path>-|')
       ${optionalString dedentOutput ''
-        # nix indents every continuation line of a multi-line error by 7 spaces
-        output=$(echo "$output" | sed 's|^       ||')
+        # nix indents every continuation line of a multi-line error;
+        # strip whatever leading whitespace it used so the width isn't hardcoded
+        output=$(echo "$output" | sed 's|^ *||')
       ''}
       ${if success then "assert_success" else "assert_failure"}
       ${optionalString (outputFile != "") "assert_output ${optionalString partialMatchOutput "--partial"} ${escapeShellArg (fileContents outputFile)}"}
+      ${optionalString (refuteOutput != "") "refute_output --partial ${escapeShellArg refuteOutput}"}
       }
     '';
 


### PR DESCRIPTION
Closes #145.

Adds `assertions` and `warnings` as terranix options, working the way they do in
NixOS: `assertions` takes `{ assertion, message }` entries, `warnings` takes
strings, both are internal and merge by list concatenation so any module can
contribute.

Enforcement is a single `lib.asserts.checkAssertWarn` call in `core/default.nix`,
wrapping the emitted config the way `top-level.nix` wraps the system derivation.
Everything funnels through there — the CLI, `evalTerranixConfiguration`,
`terranixConfiguration`, the flake-parts module — so nothing can skip the check,
and borrowing nixpkgs' function instead of reimplementing it keeps the error
format in sync for free. `core/default.nix` now returns `assertions` and
`warnings` next to `config` and `_meta`; only forcing `config` throws, so a
failed assertion doesn't stop you reading the rest.

`modules/terraform/backends.nix` moves onto it, which is the visible payoff:
define two backends *and* two remote states with the same name, and you now hear
about both instead of whichever `mkAssert` happened to be forced first.
`lib.mkAssert` is nixpkgs', not ours, so it stays available — the manual now
presents it as the escape hatch for guarding a value that must not be evaluated
at all.

Two things that will bite someone:

- Failures print a `Failed assertions:` header with one `- <msg>` line per
  failure, where they used to print `Failed assertion: <msg>`. Anyone matching
  that string in CI will need to adjust.
- A module that already declares its own top-level `assertions` or `warnings`
  option now hits a duplicate-declaration error, with no fix but renaming. NixOS
  made the same trade and I think it's worth it, but it is a break.

Both are in the changelog.

The first commit is pure `nixpkgs-fmt` with no behaviour change:
`core/terraform-options.nix` had drifted to nixfmt-rfc-style while `treefmt.toml`
says `nixpkgs-fmt`, so running the formatter touched 49 lines unrelated to any of
this. Split out to keep the feature commit readable — drop it if you'd rather
leave the file alone.

Tests are three new bats cases, plus a pure-Nix check for the "result stays
readable after a failed assertion" contract, which bats can't reach since it only
drives the CLI and that always forces `config`. `tests/test.nix` gains an opt-in
`dedentOutput` flag so a multi-line error can be matched as written.
